### PR TITLE
Update auto restart restriction

### DIFF
--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -1568,12 +1568,11 @@ To prevent large numbers of suites attempting to restart simultaneously the
 Suites will wait for a random period of time between zero and
 ``auto restart delay`` seconds before attempting to stop and restart.
 
-At present the auto shutdown-restart functionality can only operate provided
-that the user hasn't specified any behaviour which is not preserved by
-``cylc restart`` (e.g. user specified hold point or run mode). This
-caveat will be removed in a future version, currently Cylc will not attempt to
-auto shutdown-restart suites which meet this criterion but will log a critical
-error message to alert the user.
+Suites that are started up in no-detach mode cannot be auto stop-restart on a
+different host - as it will still end up attached to the condemned hosts.
+Therefore, a suite in no-detach mode running on a condemned host will abort with
+a non-zero return code. The parent process should manually handle the restart of
+the suite if desired.
 
 See the ``[suite servers]`` configuration section
 (:ref:`global-suite-servers`) for more details.

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -1568,8 +1568,8 @@ To prevent large numbers of suites attempting to restart simultaneously the
 Suites will wait for a random period of time between zero and
 ``auto restart delay`` seconds before attempting to stop and restart.
 
-Suites that are started up in no-detach mode cannot be auto stop-restart on a
-different host - as it will still end up attached to the condemned hosts.
+Suites that are started up in no-detach mode cannot auto stop-restart on a
+different host - as it will still end up attached to the condemned host.
 Therefore, a suite in no-detach mode running on a condemned host will abort with
 a non-zero return code. The parent process should manually handle the restart of
 the suite if desired.


### PR DESCRIPTION
Auto restart is only restricted for no detach mode suites.

Doc change for cylc/cylc-flow#3184