### PR TITLE
Remove (now cross-repo) references to minor files

### DIFF
--- a/doc/src/appendices/appendices-master.rst
+++ b/doc/src/appendices/appendices-master.rst
@@ -11,8 +11,6 @@ Appendices
    site-user-config-ref
    remote-job-management
    command-ref
-   readme-file
-   install-file
    dev-history-major-changes
    known-issues
    licensing

--- a/doc/src/appendices/install-file.rst
+++ b/doc/src/appendices/install-file.rst
@@ -1,4 +1,0 @@
-Cylc INSTALL File
-=================
-
-.. literalinclude:: ../../../INSTALL.md

--- a/doc/src/appendices/readme-file.rst
+++ b/doc/src/appendices/readme-file.rst
@@ -1,9 +1,0 @@
-Cylc README File
-================
-
-.. literalinclude:: ../../../README.md
-
-
-.. only:: builder_html
-
-   .. include:: ../custom/whitespace_include

--- a/doc/src/global-flow-conf.rst
+++ b/doc/src/global-flow-conf.rst
@@ -6,10 +6,31 @@ Global (Site, User) Configuration Files
 Cylc site and user global configuration files contain settings that affect all
 suites. Some of these, such as the range of network ports used by cylc,
 should be set in the site ``flow.rc`` config file. Legal items,
-values, and system defaults are documented in (:ref:`SiteRCReference`).
+values, and system defaults are documented in :ref:`SiteRCReference`.
 
 Others, such as the preferred text editor for suite configurations,
-can be overridden by users in ``~/.cylc/flow/<CYLC_VERSION>/flow.rc``
+can be overridden by users in ``~/.cylc/flow/<CYLC_VERSION>/flow.rc``.
 
-.. literalinclude:: ../../cylc/flow/etc/flow.rc.eg
-   :language: none
+
+How to create a site or user flow.rc config file
+------------------------------------------------
+
+The ``cylc get-global-config`` command prints global config defaults,
+overridden by site global settings (if any), overridden by user global
+settings (if any).
+
+To generate a new global config file:
+
+1. Run ``$ cylc get-global-config > flow.rc``
+2. Edit any settings that you need to modify.
+3. Delete or comment out any seeting you do not need (to avoid inadvertently
+   overriding defaults or site settings that may change in the future).
+
+For all legal items, see the :ref:`SiteRCReference`.
+
+
+File locations:
+^^^^^^^^^^^^^^^
+
+- **Site**: ``/etc/cylc/flow/$CYLC_VERSION/flow.rc``
+- **User**: ``$HOME/.cylc/flow/$CYLC_VERSION/flow.rc``


### PR DESCRIPTION
When building the docs (as per the instructions in the ``README.md`` here) I get a few Sphinx warnings. I'm using ``Sphinx v2.0.1``, but the nature of the warnings mean they should appear for any version; they both arise because there are references for raw inclusion (via the ``literalinclude`` directive) of some files that are still in, & belong, in the ``cylc-flow`` directory, so are no longer in this repository (see also #20).

Fortunately, these are all minor &mostly unhelpful files, so are easy to deal with; no cross-repo referencing or duplication is required:

* ``INSTALL.md`` was very out of date (I will open an Issue to register this) & there is an Installation section for this anyway :arrow_right: remove the section which just prints it;
* ``README.md`` is viewable more accessibly & agreeably in markdown via the GitHub codebase & currently pointing to the wrong file (the one in ``cylc-flow`` is the appropriate one here) :arrow_right: ditto;
* the example suite definition, ``flow.rc.eg``, outlines a small amount of important information regarding the ``flow.rc`` (view that file [here](https://github.com/cylc/cylc-flow/blob/master/cylc/flow/etc/flow.rc.eg)) :arrow_right: just place that content (formatted to RST) into the docs proper, in the same location it was previously included.

With the above amendments, the warnings naturally are resolved & no longer appear. We then achieve a clean docs build.