### PR TITLE
Fix scale-images script

### DIFF
--- a/src/graphics/scale-images.sh
+++ b/src/graphics/scale-images.sh
@@ -31,6 +31,7 @@ set -e
 # "different" binary files each time.
 mkdir -p png/scaled
 for PNG in "png/orig/"*; do
+    PNG=$(basename "${PNG}")
     if [[ ! -f png/scaled/$PNG ]]; then
         echo "scaling $PNG"
         convert -resize '600>' "png/orig/$PNG" "png/scaled/$PNG"


### PR DESCRIPTION
For the #29 PR I tried to run this script to have a matching image in the scaled directory, but it refused to work, and after some `echo`ing, it appears the value of the `PNG` variable had the directory structure too, resulting in 

```bash
(venv) kinow@kinow-VirtualBox:~/Development/python/workspace/cylc-doc/doc/src/graphics$ ./scale-images.sh
scaling png/orig/anatomy-of-a-job-script.png
convert-im6.q16: unable to open image `png/orig/png/orig/anatomy-of-a-job-script.png': No such file or directory @ error/blob.c/OpenBlob/2701.
convert-im6.q16: no images defined `png/scaled/png/orig/anatomy-of-a-job-script.png' @ error/convert.c/ConvertImageCommand/3258.
```

Cheers
Bruno