### PR TITLE
update cylc_lang extension

### DIFF
--- a/src/ext/cylc_lang.py
+++ b/src/ext/cylc_lang.py
@@ -174,16 +174,26 @@ class CylcLexer(RegexLexer):
         ],
 
         # Task inter-cycle offset for graphing:  foo[-P1DT1M]
+        # Legal formats: POINT, POINT[+-]OFFSET, OFFSET
         'intercycle-offset': [
-            include('integer-duration'),
+            include('cycle-point'),
+            include('integer-duration'),  # matches a subset of iso8601
             include('iso8601-duration'),
             (r'[\^\$]', INTERCYCLE_OFFSET_TOKEN),
             (r'\]', Text, '#pop')
         ],
 
+        # generic Cylc cycle point:  2000
+        'cycle-point': [
+            # validating the cycle point as a regex [effectively] requires
+            # knowledge of the cycling mode so is not *really* possible,
+            # also validating iso8601 datetimes is horrible.
+            (r'[\+\-]?[\d\:\-T]+(Z)?\b', INTERCYCLE_OFFSET_TOKEN)
+        ],
+
         # An integer duration:  +P1
         'integer-duration': [
-            (r'[+-]P\d+(?![\w-])', INTERCYCLE_OFFSET_TOKEN)
+            (r'([+-])?P\d+(?![\w-])', INTERCYCLE_OFFSET_TOKEN)
         ],
 
         # An ISO8601 duration:  +P1DT1H


### PR DESCRIPTION
Address syntax highlighting part of https://github.com/cylc/cylc-doc/pull/38#pullrequestreview-267514649.

Turns out that the `cylc_lang` extension in cylc-doc had got out of date with the one in rose.

The cylc-doc repository should be seen as the canonical location for Cylc Sphinx extensions. In the future we may remove it from Rose and find some way to import it from cylc-doc.