### PR TITLE
Remove duplicate EmPy regex declaration

### DIFF
--- a/src/ext/cylc_lang.py
+++ b/src/ext/cylc_lang.py
@@ -37,7 +37,6 @@ class CylcLexer(RegexLexer):
     EXTERNAL_SUITE_TOKEN = Name.Builtin.Pseudo
     INTERCYCLE_OFFSET_TOKEN = Name.Builtin
 
-    EMPY_BLOCK_REGEX = r'@\{([^\{\}]+|\{[^\}]+\})+\}'
     EMPY_BLOCK_REGEX = (
         r'@\%(open)s('  # open empy block
         r'[^\%(open)s\%(close)s]+|'  # either not a close character


### PR DESCRIPTION
Confirmed with @oliver-sanders already in #46 that this one can go :+1: and one review should do it.

This closes #46