### PR TITLE
Update copyright notice for setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
See https://github.com/cylc/cylc-flow/pull/3310#issue-310635758 where the exact same case applies here, except this time only one file (the ``setup.py`` again) in the repo had an old copyright notice.