### PR TITLE
Update echo xtrigger in line with current (Python 3) code

### DIFF
--- a/src/external-triggers.rst
+++ b/src/external-triggers.rst
@@ -298,7 +298,7 @@ Toy Examples
 echo
 """"
 
-The trivial built in ``echo`` function takes any number of positional
+The trivial built-in ``echo`` function takes any number of positional
 and keyword arguments (from the suite configuration) and simply prints
 them to stdout, and then returns False (i.e. trigger condition not
 satisfied). Here it is in its entirety.
@@ -306,9 +306,9 @@ satisfied). Here it is in its entirety.
 .. code-block:: python
 
    def echo(*args, **kwargs):
-       print "echo: ARGS:", args
-       print "echo: KWARGS:", kwargs
-       return (False, {})
+       print("echo: ARGS:", args)
+       print("echo: KWARGS:", kwargs)
+       return False, {}
 
 Here's an example echo trigger suite:
 
@@ -332,7 +332,7 @@ your terminal).
 xrandom
 """""""
 
-The built in ``xrandom`` function sleeps for a configurable amount of
+The built-in ``xrandom`` function sleeps for a configurable amount of
 time (useful for testing the effect of a long-running trigger function
 - which should be avoided) and has a configurable random chance of
 success. The function signature is:


### PR DESCRIPTION
The built-in "custom" xtrigger ``echo`` is directly written out in the docs, & is now out of date, as the [actual xtrigger code](https://github.com/cylc/cylc-flow/blob/283bda1da40ee0d3baa14556000f4d6a4e3f4d43/cylc/flow/xtriggers/echo.py#L28-L29) (see also the [xtriggers directory equivalent](https://github.com/cylc/cylc-xtriggers/blob/a83eb011021cf67f96e79c14f4e003fa7d3f2ab8/cylc/flow/xtriggers/echo.py#L27-L28)) was updated from Python 2 to 3.

Ideally, instead of just updating the written-in code to match (actually, strictly I made it match the xtrigger repo version without the tuple parentheses in the return value, as they are not required), we could use a ``literalinclude:`` directive to add in the code itself, ensuring it will stay up-to-date, but I am not sure if that would be too much hassle to set-up, given:

* it requires connecting up to the ``cylc-flow`` repo to access the ``echo.py`` file;
* there is only one xtrigger example shown, & this ``echo`` example is so trivial it is unlikely to change again.

Are we happy with this "simple content update" approach for now? If not, let me know, & I can amend this accordingly.