### PR TITLE
Document Python versions xtriggers must be written in

### DIFF
--- a/src/external-triggers.rst
+++ b/src/external-triggers.rst
@@ -221,10 +221,18 @@ Custom Trigger Functions
 Trigger functions are just normal Python functions, with a few special
 properties:
 
-- they must be defined in a module with the same name as the function
-- they can be located in:
-  - ``<suite-dir>/lib/python/``
-  - (or anywhere in your Python library path)
+- they must:
+
+  - be defined in a module with the same name as the function;
+  - be compatible with the same Python version that runs the Cylc workflow
+    server program (see :ref:`Requirements` for the latest version
+    specification).
+
+- they can be located either:
+
+  - in ``<suite-dir>/lib/python/``;
+  - or anywhere in your Python library path.
+
 - they can take arbitrary positional and keyword arguments
 - suite and task identity, and cycle point, can be passed to trigger
   functions by using string templates in function arguments (see below)


### PR DESCRIPTION
Close #66.

Note that Sphinx will only create nested bullet points when there are blank lines separating the parent & child nesting levels, so in ``master`` there is a desired sub-list that has not been rendered as such, hence the included changes to the formatting.