### PR TITLE
Remove obsolete run dir housekeeping docs.

### DIFF
--- a/src/appendices/site-user-config-ref.rst
+++ b/src/appendices/site-user-config-ref.rst
@@ -66,30 +66,13 @@ safety measure, however, so command prompts are disabled by default.
 - *default*: True
 
 
-enable run directory housekeeping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The suite run directory tree is created anew with every suite start
-(not restart) but output from the most recent previous runs can be
-retained in a rolling archive. Set length to 0 to keep no backups.
-**This is incompatible with current Rose suite housekeeping** (see
-:ref:`SuiteStorageEtc` for more on Rose) so it is disabled by
-default, in which case new suite run files will overwrite existing ones
-in the same run directory tree. Rarely, this can result in incorrect
-polling results due to the presence of old task status files.
-
-- *type*: boolean
-- *default*: False
-
-
 run directory rolling archive length
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The number of old run directory trees to retain if run directory
-housekeeping is enabled.
+The number of old run directory trees to retain at start-up.
 
 - *type*: integer
-- *default*: 2
+- *default*: all
 
 
 task host select command timeout


### PR DESCRIPTION
- remove documentation of obsolete `enable run directory housekeeping`
- update documentation of `run directory rolling archive length`

See:
- https://github.com/cylc/cylc-flow/issues/2732 
- https://github.com/cylc/cylc-flow/pull/3326
