### PR TITLE
Update PBS job name max len from 15 to 236

### DIFF
--- a/src/appendices/site-user-config-ref.rst
+++ b/src/appendices/site-user-config-ref.rst
@@ -609,12 +609,11 @@ not use the normal log file location while the job is running.
 
 The maximum length for job name acceptable by a batch system on a given host.
 Currently, this setting is only meaningful for PBS jobs. For example, PBS 12
-or older will fail a job submit if the job name has more than 15 characters,
-which is the default setting. If you have PBS 13 or above, you may want to
-modify this setting to a larger value.
+or older will fail a job submit if the job name has more than 15 characters;
+whereas PBS 13 accepts up to 236 characters.
 
 - *type*: integer
-- *default*: (none)
+- *default*: 236
 - *example*:  For PBS:
 
 .. code-block:: cylc
@@ -623,8 +622,8 @@ modify this setting to a larger value.
        [[myhpc*]]
            [[[batch systems]]]
                [[[[pbs]]]]
-                   # PBS 13
-                   job name length maximum = 236
+                   # PBS <=12
+                   job name length maximum = 15
 
 
 .. _ExecutionTimeLimitPollingIntervals:

--- a/src/task-job-submission.rst
+++ b/src/task-job-submission.rst
@@ -289,10 +289,10 @@ file paths, and the execution time limit (if specified).
 Cylc constructs the job name string using a combination of the task ID and the
 suite name. PBS fails a job submit if the job name in ``-N name`` is
 too long. For version 12 or below, this is 15 characters. For version 13, this
-is 236 characters. The default setting will truncate the job name string to 15
-characters. If you have PBS 13 at your site, you should modify your site's
-global configuration file to allow the job name to be longer. (See also
-:ref:`JobNameLengthMaximum`.) For example:
+is 236 characters. The default setting will truncate the job name string to 236
+characters. If you have PBS 12 or older at your site, you should modify your
+site's global configuration file to allow the job name to be truncated at 15
+characters. (See also :ref:`JobNameLengthMaximum`.) For example:
 
 .. code-block:: cylc
 
@@ -301,7 +301,7 @@ global configuration file to allow the job name to be longer. (See also
            [[[batch systems]]]
                [[[[pbs]]]]
                    # PBS 13
-                   job name length maximum = 236
+                   job name length maximum = 15
 
 
 Directives Section Quirks (PBS, SGE, ...)


### PR DESCRIPTION
The default assumes PBS 13 or newer. Companion of cylc/cylc-flow#3356.