### PR TITLE
document coreutuils dependency

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -31,8 +31,10 @@ The following packages are necessary for running tests in Cylc:
 
 To generate the HTML User Guide, you will need:
 
-- `Sphinx <http://www.sphinx-doc.org/en/master/>`_ of compatible version,
-  ``>=`` **1.5.3** and ``<=`` **1.7.9**.
+- `Sphinx <http://www.sphinx-doc.org/en/master/>`_ 2.0+.
+
+
+.. TODO: Remove or fix this section once deployment has been sorted.
 
 To check that dependencies are installed and environment is configured
 correctly run ``cylc check-software``:

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -10,6 +10,8 @@ including Apple OS X, but they are not officially tested and supported.
 Third-Party Software Packages
 -----------------------------
 
+.. _GNU Coreutils: https://www.gnu.org/software/coreutils/coreutils.html
+
 Requirements:
 
 - Python 3.7+
@@ -17,6 +19,11 @@ Requirements:
   - `python-jose <https://pypi.org/project/python-jose/>`_
   - `zmq <https://pypi.org/project/zmq/>`_
   - `colorama <https://pypi.org/project/colorama/>`_
+
+- `GNU Coreutils`_
+
+  - These must be available in the Cylc environment using the canonical names
+    (e.g. ``ls``).
 
 The following packages are necessary for running tests in Cylc:
 


### PR DESCRIPTION
Whilst this section will be re-written anyway we should make a note of our `coreutils` dependency.

Coreutils is required for basic functionality (e.g. the `timeout` command used within Cylc Flow) and optional functionality (e.g. the functional tests which use non-POSIX stuff like `sed -r`).

Note: We need Coreutils to be installed "as normal", e.g. on BSD it is safer to install commands with a prefix (e.g. `ls` => `gls`) to avoid conflict with the BSD equivalents. Typical workaround is to fudge it in the `.bashrc` file. Will add instructions for this when deployment is sorted.