### PR TITLE
fail build on invalid references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # You can set these variables from the command line:
 # e.g. $ make html CYLC_VERSION=1.2.3
 CYLC_VERSION = $(shell cylc version | sed 's/Cylc Flow //')
-SPHINXOPTS =
+SPHINXOPTS = -n
 SPHINXBUILD = sphinx-build
 SOURCEDIR = src
 BUILDDIR = doc/$(CYLC_VERSION)

--- a/src/conf.py
+++ b/src/conf.py
@@ -86,6 +86,9 @@ release = CYLC_VERSION  # The full version, including alpha/beta/rc tags.
 intersphinx_mapping = {
     'rose': (
         'http://metomi.github.io/rose/doc/html', None
+    ),
+    'python': (
+        'https://docs.python.org/', None
     )
 }
 

--- a/src/tutorial/runtime/introduction.rst
+++ b/src/tutorial/runtime/introduction.rst
@@ -69,8 +69,8 @@ We can also call other scripts or executables in this way, e.g:
            script = ~/foo/bar/baz/hello_world
 
 
-:envvar:`PATH` and :envvar:`PYTHONPATH`
----------------------------------------
+``PATH`` and :envvar:`PYTHONPATH`
+---------------------------------
 
 .. ifnotslides::
 
@@ -78,7 +78,7 @@ We can also call other scripts or executables in this way, e.g:
    leaving them somewhere else on the system.
 
    If you create a ``bin/`` sub-directory within the :term:`suite directory`
-   Cylc will automatically prepend it to the :envvar:`PATH` environment
+   Cylc will automatically prepend it to the ``PATH`` environment
    variable when the task runs.
 
 .. code-block:: bash


### PR DESCRIPTION
Cause the Sphinx build to fail if any references are missing / corrupted. E.G. if you try to reference a python function which isn't documented you get an error.

This will be especially useful when we document more things like Cylc configurations etc.

This should fail until https://github.com/cylc/cylc-flow/pull/3417 is merged.