### PR TITLE
Fix example in parameter expansion

### DIFF
--- a/src/suite-config.rst
+++ b/src/suite-config.rst
@@ -2787,7 +2787,7 @@ expands to:
 .. code-block:: cylc
 
    R1 = """proc_small => proc_big
-              proc_big => proc_huge"""
+           proc_big => proc_huge"""
 
    # or equivalently:
 

--- a/src/suite-config.rst
+++ b/src/suite-config.rst
@@ -2489,13 +2489,13 @@ configuration. For the values above, this parameterized name:
 
 .. code-block:: none
 
-   model<run>  # for run = 1..2
+   model<run>  # for run = 1..5
 
 expands to these concrete task names:
 
 .. code-block:: none
 
-   model_run1, model_run2
+   model_run1, model_run2, model_run3, model_run4, model_run5
 
 and this parameterized name:
 

--- a/src/suite-config.rst
+++ b/src/suite-config.rst
@@ -2817,7 +2817,7 @@ graph.
 .. code-block:: cylc
 
    R1 = """foo<m-1> => foo<m>  # for m = cat, dog
-              baz => foo<m>"""
+           baz => foo<m>"""
 
 
 Task Families And Parameterization


### PR DESCRIPTION
Three commits, one uses `1..5` for parameter expansion. The examples appear to be related to a previous paragraph, where the docs use `1..5`, `ship, buoy, plane` for obs, etc. The examples match the content in that previous paragraph, except for this one, that is using 1..2.

The other commits were to align the multiline string in the examples. There is one example with multiline string that is aligned correctly, but the two subsequent examples appear to be off by a couple spaces?