### PR TITLE
Attempt to fix broken link

### DIFF
--- a/src/tutorial/scheduling/datetime-cycling.rst
+++ b/src/tutorial/scheduling/datetime-cycling.rst
@@ -1,4 +1,4 @@
-.. _nowcasting: https://www.en.wikipedia.org/wiki/Nowcasting_(meteorology)
+.. _nowcasting: https://en.wikipedia.org/wiki/Nowcasting_(meteorology)
 
 .. _tutorial-datetime-cycling:
 


### PR DESCRIPTION
Link to wikipedia broken. Suggested change: https://en.wikipedia.org/wiki/Nowcasting_(meteorology)