### PR TITLE
Adding initial docs for websockets security

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -15,4 +15,5 @@ indefinitely.
    user-guide/index
    suite-design-guide/index
    reference/index
+   security
    glossary

--- a/src/security.rst
+++ b/src/security.rst
@@ -1,0 +1,57 @@
+Security
+========
+
+TODO: Fill in other parts of this document, with information about
+cylc-flow (jobs, zmq, etc), UI Server, etc.
+
+Web
+~~~
+
+TODO: write some introduction about web security in Cylc 8,
+UI Server, OAuth, JupyterHub Authenticators, etc.
+
+WebSockets
+^^^^^^^^^^
+
+Frontend and backend communication with WebSockets in Cylc is secured through
+WebSocket Secure, cookie-based authentication, and same origin backend
+verification.
+
+WebSocket Secure
+````````````````
+
+The WebSocket protocol supports the ``ws`` and the ``wss`` protocol URI
+identifiers. The former means "WebSocket", and the latter means
+"WebSocket Secure". It is recommended to use ``wss`` so that the
+communication is encrypted and attacks such as MITM are avoided.
+
+The ``wss`` identifier can only be used when SSL is enabled. JupyterHub
+has `a section on how to enable SSL`_ in their documentation. Once SSL
+is enabled the Cylc web UI automatically detects it and uses ``wss``.
+
+.. _`a section on how to enable SSL`: https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html#enabling-ssl-encryption
+
+Cookie-based authentication
+```````````````````````````
+
+When the frontend initiates the communication with the backend it will send
+an HTTP request that will include the client cookies. The backend expects
+a valid `JupyterHub user cookie`_.
+
+.. _`JupyterHub user cookie`: https://jupyterhub.readthedocs.io/en/latest/getting-started/security-basics.html#jupyterhub-user-username
+
+If the cookie is valid a connection will be established and
+the query response will be sent to the frontend.
+
+If the cookie is invalid (e.g. cookie secret changed in the server)
+or if the cookie is not present (e.g. user not authenticated)
+the backend will return an HTTP 403 error and the connection
+will be closed.
+
+If the backend log level is set to ``DEBUG`` a message will be
+emitted in the logs alerting about the unauthorized access.
+
+Same-origin verification
+````````````````````````
+
+TODO: pending Cylc UI Server same-origin verification and docs

--- a/src/security.rst
+++ b/src/security.rst
@@ -5,7 +5,7 @@ TODO: Fill in other parts of this document, with information about
 cylc-flow (jobs, zmq, etc), UI Server, etc.
 
 Web
-~~~
+---
 
 TODO: write some introduction about web security in Cylc 8,
 UI Server, OAuth, JupyterHub Authenticators, etc.
@@ -18,7 +18,7 @@ WebSocket Secure, cookie-based authentication, and same origin backend
 verification.
 
 WebSocket Secure
-````````````````
+""""""""""""""""
 
 The WebSocket protocol supports the ``ws`` and the ``wss`` protocol URI
 identifiers. The former means "WebSocket", and the latter means
@@ -32,7 +32,7 @@ is enabled the Cylc web UI automatically detects it and uses ``wss``.
 .. _`a section on how to enable SSL`: https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html#enabling-ssl-encryption
 
 Cookie-based authentication
-```````````````````````````
+"""""""""""""""""""""""""""
 
 When the frontend initiates the communication with the backend it will send
 an HTTP request that will include the client cookies. The backend expects
@@ -52,7 +52,7 @@ If the backend log level is set to ``DEBUG`` a message will be
 emitted in the logs alerting about the unauthorized access.
 
 Same-origin verification
-````````````````````````
+""""""""""""""""""""""""
 
 When a client tries to open a WebSocket with the Cylc UI Server, it
 will pass by a same-origin verification. This test is useful to prevent

--- a/src/security.rst
+++ b/src/security.rst
@@ -54,4 +54,21 @@ emitted in the logs alerting about the unauthorized access.
 Same-origin verification
 ````````````````````````
 
-TODO: pending Cylc UI Server same-origin verification and docs
+When a client tries to open a WebSocket with the Cylc UI Server, it
+will pass by a same-origin verification. This test is useful to prevent
+attacks such as `CORS`_.
+
+This verification only occurs when the client provides an ``Origin``
+HTTP header - which browsers normally do. Command line applications
+do not necessarily provide this header, but CORS is normally not an
+issue for that case.
+
+Cylc UI Server uses Tornado's default `same-origin policy`_.
+So whenever a client sends a request with the ``Origin`` header,
+the server will compare it against the ``Host`` HTTP header.
+
+If these values do not match, an error is logged and returned to the
+client.
+
+.. _`CORS`: https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny
+.. _`same-origin policy`: https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.check_origin


### PR DESCRIPTION
Relates to the Cylc UI Server 0.3 work to verify user authentication with WebSockets: https://github.com/cylc/cylc-uiserver/pull/124, and also to the work to use Tornado's default `check_origin` function: https://github.com/cylc/cylc-uiserver/pull/125