### PR TITLE
decouple sphinx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@
 # More information for Travis can be found at http://docs.travis-ci.com/user/getting-started/
 
 ---
-cache: pip
 dist: xenial
 
 language: python

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ VERSION = get_version(
 )
 
 INSTALL_REQUIRES = [
-    'sphinx==2.0.*',
+    'sphinx>=2.0.0,<3.0.0',
     'sphinx_rtd_theme',
     'sphinxcontrib-svg2pdfconverter',
     'hieroglyph',


### PR DESCRIPTION
The rate of Sphinx development is too fast to keep manually pinning it to a subversion ~(we will soon be on Sphinx3)~ Sphinx 3 is out.

Also we are using tools, which for good reason do pin the sphinx version. So at present Cylc-doc is incompatible with cylc-sphinx-extensions.

Set a looser definition of what we want based on what we actually need.