### PR TITLE
Fix badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   test:
@@ -60,6 +63,6 @@ jobs:
       - name: debug
         if: failure()
         run: |
-          env 
+          env
           cat /tmp/sphinx-err* || true  # sphinx traceback
           find ~/cylc-run -name job.err -exec cat {} +  # cylc error files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cylc Documentation
 
-[![Build Status](https://travis-ci.org/cylc/cylc-doc.svg?branch=master)](https://travis-ci.org/cylc/cylc-doc)
+![test](https://github.com/cylc/cylc-doc/workflows/test/badge.svg?branch=master&event=push)
 
 Documentation for the Cylc Workflow Engine and its software ecosystem.
 


### PR DESCRIPTION
- The test workflow now also runs when a commit is pushed to master (including PR merge).
- The badge only shows the status of test workflow run on push on master

This supersedes #126 