### PR TITLE
Remove reference to cylc submit and jobscript CLI commands

### DIFF
--- a/src/suites/inherit/single/two/suite.rc
+++ b/src/suites/inherit/single/two/suite.rc
@@ -3,8 +3,7 @@
 
     description = """
 This suite illustrates several tiers of task runtime inheritance.
-To see the result, use 'cylc get-config' or examine task job scripts
-generated with 'cylc jobscript'."""
+To see the result, use 'cylc get-config'."""
 
 [scheduling]
     initial cycle point = 20110101T00

--- a/src/user-guide/task-implementation.rst
+++ b/src/user-guide/task-implementation.rst
@@ -35,8 +35,7 @@ part of the script can potentially affect the environment of subsequent parts.
    dependency graph).
 
 Task job scripts are written to the suite's job log directory. They can be
-printed with ``cylc cat-log`` or generated and printed with
-``cylc jobscript``.
+printed with ``cylc cat-log``.
 
 Inlined Tasks
 -------------

--- a/src/user-guide/task-job-submission.rst
+++ b/src/user-guide/task-job-submission.rst
@@ -595,23 +595,9 @@ name in suite configurations:
                -q = long
                -V =
 
-Generate a job script to see the resulting directives:
-
-.. code-block:: bash
-
-   $ cylc register test $HOME/test
-   $ cylc jobscript test a.1 | grep QSUB
-   #QSUB -e /home/oliverh/cylc-run/my.suite/log/job/1/a/01/job.err
-   #QSUB -l nodes=1
-   #QSUB -l walltime=60
-   #QSUB -o /home/oliverh/cylc-run/my.suite/log/job/1/a/01/job.out
-   #QSUB -N a.1
-   #QSUB -q long
-   #QSUB -V
-
-(Of course this suite will fail at run time because we only changed the
+Note, this suite will fail at run time because we only changed the
 directive format, and PBS does not accept ``#QSUB`` directives in
-reality).
+reality.
 
 
 .. _Where To Put Batch System Handler Modules:

--- a/src/user-guide/writing-suites.rst
+++ b/src/user-guide/writing-suites.rst
@@ -3628,8 +3628,7 @@ allows you to temporarily remove tasks from the suite by simply
 commenting them out of the graph.
 
 To omit a task from the suite at runtime but still leave it fully
-defined and available for use (by insertion or ``cylc submit``)
-use one or both of
+defined and available for use (by insertion) use one or both of
 :cylc:conf:`[scheduling][special tasks]include at start-up` or
 :cylc:conf:`[scheduling][special tasks]exclude at start-up`.
 Then the graph still defines the


### PR DESCRIPTION
Since https://github.com/cylc/cylc-flow/pull/3653, references to these commands are no longer accurate.

Note there are still references to `jobscript` but these are still necessary as it is only the CLI command references that need removing, cylc still generates jobscripts.

I think this closes https://github.com/cylc/cylc-doc/issues/130, unless there are other commands I have missed! I also checked for references to cylc scp-transfer but none there.

 