### PR TITLE
actions: nightly builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,118 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2020 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Deploy a new version of the documentation or rebuild an existing one.
+
+# Note: All changes made to the gh-pages branch are non-destructive 
+#       (i.e. no force pushing) so all changes can be undone.
+
+name: nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '35 0 * * *'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: checkout cylc-doc
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: docs
+
+      - name: install graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz pkg-config libgraphviz-dev
+          pip install pygraphviz
+
+      - name: install cylc-doc
+        run: |
+          pip install "${{ github.workspace }}/docs[all]"
+
+      - name: checkout cylc-flow
+        uses: actions/checkout@v2
+        with:
+          repository: cylc/cylc-flow
+          ref: master
+          path: cylc-flow
+
+      - name: install cylc-flow
+        run: |
+          # NOTE: Install with [all] so we can import plugins which may
+          #       have extra dependencies.
+          pip install './cylc-flow[all]'
+
+      - name: checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: install gh-pages
+        run: |
+          DOCS="${{ github.workspace }}/docs" \
+          PAGE="${{ github.workspace }}/gh-pages"  \
+
+          (
+            cd "$DOCS"
+            rm -r doc
+            ln -s "$PAGE" doc
+          )
+
+          ls -l "$DOCS"
+
+      - name: build docs
+        run: |
+          # remove previous build
+          rm -r docs/nightly || true
+          # make new build
+          make -C docs \
+            html \
+            slides \
+            linkcheck \
+            SPHINXOPTS='-Wn' \
+            SETCURRENT=false \
+            CYLC_VERSION=nightly
+
+      - name: configure git
+        run: |
+          git config --global user.name "action:deploy"
+          git config --global user.email "action:deploy@github.com"
+
+      - name: tidy old versions
+        run: |
+          (
+            cd docs
+            git rm -r $("${{ github.workspace }}/docs/bin/version" tidy) || true
+          )
+
+      - name: push changes
+        run: |
+          (
+            cd gh-pages
+            git add *
+            git commit -m 'nightly build'
+            git push origin HEAD
+          )

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
           path: gh-pages
 
       - name: sync static files
+        if: ${{ github.event.inputs.set_current }}
         run: |
           DOCS="${{ github.workspace }}/docs" \
           PAGE="${{ github.workspace }}/gh-pages"  \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: remove previous nightly build
         run: |
-          EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/omit \1/"' \
+          EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/drop \1/"' \
             git -C gh-pages rebase -i --keep-base
 
       - name: build docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,44 +75,33 @@ jobs:
           DOCS="${{ github.workspace }}/docs" \
           PAGE="${{ github.workspace }}/gh-pages"  \
 
-          (
-            cd "$DOCS"
-            rm -r doc
-            ln -s "$PAGE" doc
-          )
-
-          ls -l "$DOCS"
-
-      - name: build docs
-        run: |
-          # remove previous build
-          rm -r docs/nightly || true
-          # make new build
-          make -C docs \
-            html \
-            slides \
-            linkcheck \
-            SPHINXOPTS='-Wn' \
-            SETCURRENT=false \
-            CYLC_VERSION=nightly
+          cd "$DOCS"
+          rm -r doc
+          ln -s "$PAGE" doc
 
       - name: configure git
         run: |
           git config --global user.name "action:deploy"
           git config --global user.email "action:deploy@github.com"
 
-      - name: tidy old versions
+      - name: remove previous nightly build
         run: |
-          (
-            cd docs
-            git rm -r $("${{ github.workspace }}/docs/bin/version" tidy) || true
-          )
+          EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/omit \1/"' \
+            git -C gh-pages rebase -i --keep-base
+
+      - name: build docs
+        run: |
+          build_name="nightly.$(isodatetime --utc -f %Y-%m-%d)"
+          make -C docs \
+            html \
+            slides \
+            linkcheck \
+            SPHINXOPTS='-Wn' \
+            SETCURRENT=false \
+            CYLC_VERSION="$build_name"
+          git -C gh-pages add "$build_name" 'versions.json'
 
       - name: push changes
         run: |
-          (
-            cd gh-pages
-            git add *
-            git commit -m 'nightly build'
-            git push origin HEAD
-          )
+          git -C gh-pages commit -m '-nightly build-'
+          git -C gh-pages push origin HEAD

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,20 @@ cleanall:
 	(cd doc; echo [0-9]*.*)
 	rm -rI doc/[0-9]*.*
 
-.PHONY: help clean Makefile
+.PHONY: help clean Makefile .EXPORT_ALL_VARIABLES
 
-finally =
+default_version =
 ifeq ($(SETCURRENT),true)
-	finally = bin/set-default-path "$(BUILDDIR)" "$(CYLC_VERSION)" html
+	default_version = current
 endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+# NOTE: EXPORT_ALL_VARIABLES exports make vars as env vars
+%: Makefile .EXPORT_ALL_VARIABLES
 	# build documentation
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	# write out dict of available versions and formats
 	bin/version write > doc/versions.json
 	# setup HTML redirects to point at this version if $(SETCURRENT) == true
-	$(finally)
+	bin/set-default-path "$(BUILDDIR)" "$(CYLC_VERSION)" html "$(default_version)"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ $ make html linkcheck doctest SPHINXOPTS='-W'
 
   This has not been automated on-purpose, though if it becomes a problem
   we could potentially setup a chron job to squash all but the last N commits.
+
+## Nightly Builds
+
+The `nightly` action builds `cylc-doc:master` against `cylc-flow:master`
+and pushes the result up to `upstream/gh-pages`.
+
+This action deletes its previous commits so the nightly build history is not
+preserved and does not require housekeeping.

--- a/bin/set-default-path
+++ b/bin/set-default-path
@@ -22,7 +22,7 @@ cd "$1/.."
 
 CYLC_VERSION="$2"
 DEFAULT_FORMAT="$3"
-LATEST='current'
+LATEST="${4:-}"
 
 
 html_redirect () {
@@ -46,12 +46,15 @@ __HTML__
 
 
 main () {
-    # make the specified version of the documentation the default
-    rm "${LATEST}" || true
-    ln -s "${CYLC_VERSION}" "${LATEST}"
-    html_redirect "${LATEST}/index.html" "index.html"
-    # make the specified format the default
-    html_redirect "${DEFAULT_FORMAT}/index.html" "${LATEST}/index.html"
+    # link to the default format in the freshly built documentation
+    html_redirect "${DEFAULT_FORMAT}/index.html" "${CYLC_VERSION}/index.html"
+
+    if [[ -n $LATEST ]]; then
+        # make the specified version of the documentation the default
+        rm "${LATEST}" || true
+        ln -s "${CYLC_VERSION}" "${LATEST}"
+        html_redirect "${LATEST}/index.html" "index.html"
+    fi
 }
 
 

--- a/bin/version
+++ b/bin/version
@@ -35,6 +35,12 @@ DUMMY_FORMATS = [
 ]
 
 
+def get_versions(builddir):
+    yield from pathlib.Path(builddir).glob('[0-9]*.*')
+    yield from pathlib.Path(builddir).glob('nightly*')
+    yield from pathlib.Path(builddir).glob('dev*')
+
+
 def get_formats(builddir):
     """Return a dictionary of the form {cylc_version: [doc_format...]}."""
     return {
@@ -43,7 +49,7 @@ def get_formats(builddir):
             for format_ in version.glob('*')
             if format_.name not in DUMMY_FORMATS and '.' not in format_.name
         ]
-        for version in pathlib.Path(builddir).glob('[0-9]*.*')
+        for version in get_versions(builddir)
     }
 
 

--- a/bin/version
+++ b/bin/version
@@ -36,8 +36,9 @@ DUMMY_FORMATS = [
 
 
 def get_versions(builddir):
+    """Yield paths to each documented version."""
     yield from pathlib.Path(builddir).glob('[0-9]*.*')
-    yield from pathlib.Path(builddir).glob('nightly*')
+    yield from pathlib.Path(builddir).glob('nightly.*')
     yield from pathlib.Path(builddir).glob('dev*')
 
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -81,14 +81,16 @@ master_doc = 'index'
 project = 'Cylc'
 copyright = '2008-2020 NIWA & British Crown (Met Office) & Contributors'
 
-# Versioning information. Sphinx advises version strictly meaning X.Y.
-version = '.'.join(CYLC_VERSION.split('.')[:2])  # The short X.Y version.
-release = CYLC_VERSION  # The full version, including alpha/beta/rc tags.
+# Versioning information.
+release = os.environ['CYLC_VERSION']  # set in makefile
+version = '.'.join(release.split('.')[:2])  # short version for display
 
+# Autosummary opts (for auto generation of docs from source code).
 autosummary_generate = True
 autosummary_generate_overwrite = True
 autosummary_imported_members = False
 
+# Mapping to other Sphinx projects we want to import references from.
 intersphinx_mapping = {
     'rose': (
         'http://metomi.github.io/rose/doc/html', None


### PR DESCRIPTION
Perform a nightly build of `cylc-doc:master` against `cylc-flow:master` at around 0:35UTC.

I've managed to jigger up GH actions on my own fork which is no longer recognising the `nightly` action so I've kinda deleted the evidence that this works, will try and get it going again, in the mean time take a look at my `gh-pages` branch:

https://oliver-sanders.github.io/cylc-doc/current/html/index.html

When we perform a new nightly build we delete the commit of the last one so that the branch history doesn't inflate massively.

Sadly this is a separate workflow from `deploy` as there is just too much different between the two to unify them in any meaningful way.