### PR TITLE
Nightly rebase

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,8 +86,15 @@ jobs:
 
       - name: remove previous nightly build
         run: |
+          cd gh-pages
           EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/drop \1/"' \
-            git -C gh-pages rebase -i --keep-base
+            git rebase -i --keep-base
+          # if versions have been added/removed since the last build we
+          # will get conflicts on the versions.json file so we rebuild it
+          # now just incase
+          ../docs/bin/version write > versions.json
+          git add versions.json
+          git rebase --continue || true  # true incase there wasn't a conflict
 
       - name: build docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/appendices/command-ref.rst
 # editor stuff
 *.swp
 *~
+.vscode
 
 # auto-generated documentation
 src/user-guide/plugins/main-loop/built-in


### PR DESCRIPTION
The next nightly build will fail 😔.

This is because there will be conflicts on the `versions.json` file as I pushed up the docs for `7.8.6` and `7.9.1` today.

This PR re-generates the `version.json` file with each nightly build to overwrite any conflicts in the file.