### PR TITLE
 prevent versions from being word-wrapped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/appendices/command-ref.rst
 # editor stuff
 *.swp
 *~
+.vscode
 
 # auto-generated documentation
 src/user-guide/plugins/main-loop/built-in

--- a/doc/versions.js
+++ b/doc/versions.js
@@ -69,6 +69,7 @@ $(document).ready(function() {
                 }
                 version_div.append(
                     $('<a />')
+                        .attr({'style': 'display: inline-block'})
                         .attr({'href': url(version, vn_fmt)})
                         .css({'padding-left': '1em'})
                         .append(version)


### PR DESCRIPTION
Apply Ronnie's fix to make versions look nicer, already used on gh-pages.