### PR TITLE
setup: up sphinx_rtd_theme version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ VERSION = get_version(
 
 INSTALL_REQUIRES = [
     'sphinx>=2.0.0,<3.0.0',
-    'sphinx_rtd_theme',
+    'sphinx_rtd_theme>=0.5.0',
     'sphinxcontrib-svg2pdfconverter',
     'hieroglyph',
     'eralchemy==1.2.*',


### PR DESCRIPTION
The sphinx_rtd_theme project either had a bug or made a bad design decision (not sure which) over the styling of definition lists, as of 0.5.0 it has been fixed/reverted.

This PR pins the version so we don't get that nasty styling again:

**Before:**

<img width="497" alt="Screenshot 2020-08-19 at 17 26 09" src="https://user-images.githubusercontent.com/16705946/90663242-4cf38200-e241-11ea-9bf0-53325ab2438c.png">

**After:**

<img width="497" alt="Screenshot 2020-08-19 at 17 26 18" src="https://user-images.githubusercontent.com/16705946/90663246-4e24af00-e241-11ea-96d1-466a4658ebc1.png">
