### PR TITLE
hieroglyph_patch: remove obsolete extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,12 @@ VERSION = get_version(
 )
 
 INSTALL_REQUIRES = [
-    'sphinx>=2.0.0,<3.0.0',
+    'cylc-sphinx-extensions>=1.2'
+    'eralchemy==1.2.*',
+    'hieroglyph>=2.1.0',
+    'sphinx>=3.0.0',
     'sphinx_rtd_theme>=0.5.0',
     'sphinxcontrib-svg2pdfconverter',
-    'hieroglyph',
-    'eralchemy==1.2.*',
-    'cylc-sphinx-extensions'
 ]
 
 EXTRAS_REQUIRE = {

--- a/src/conf.py
+++ b/src/conf.py
@@ -22,9 +22,6 @@ from cylc.flow import __version__ as CYLC_VERSION
 
 # -- General configuration ------------------------------------------------
 
-# minimal Sphinx version required.
-needs_sphinx = '1.5.3'
-
 # Sphinx extension module names.
 sys.path.append(os.path.abspath('ext'))  # path to custom extensions.
 extensions = [
@@ -44,8 +41,6 @@ extensions = [
     'cylc.sphinx_ext.minicylc',
     'cylc.sphinx_ext.practical',
     'cylc.sphinx_ext.sub_lang',
-    # https://github.com/nyergler/hieroglyph/issues/148
-    'cylc.sphinx_ext.hieroglyph_patch'
 ]
 
 rst_epilog = open('hyperlinks.rst.include', 'r').read()


### PR DESCRIPTION
Sibling PR: https://github.com/cylc/cylc-sphinx-extensions/pull/32

The `hieroglyph_patch` extension is a dirty hack to get around this issue:

https://github.com/nyergler/hieroglyph/issues/148

But now that hieroglyph 2.1.0 has been released we no longer need it!

This removes the Sphinx version coupling which was locking us into an ever decreasingly small number of compatible Sphinx2 versions.