### PR TITLE
Initial file installation docs update

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -445,15 +445,12 @@ Glossary
    suite log
    suite log directory
       A Cylc suite logs events and other information to the suite log files
-      when it runs. There are four log files:
+      when it runs. There are two log files:
 
-      * ``out`` - the stdout of the suite.
-      * ``err`` - the stderr of the suite, which may contain useful debugging
-        information in the event of any error(s).
       * ``log`` - a log of suite events, consisting of information about
         user interaction.
-      * ``file-installation-log`` - a log documenting the file installation 
-        process on the remote platform.
+      * ``file-installation-log`` - a log documenting the file installation
+        process on remote platforms.
 
       The suite log directory lies within the :term:`run directory`:
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -445,13 +445,15 @@ Glossary
    suite log
    suite log directory
       A Cylc suite logs events and other information to the suite log files
-      when it runs. There are three log files:
+      when it runs. There are four log files:
 
       * ``out`` - the stdout of the suite.
       * ``err`` - the stderr of the suite, which may contain useful debugging
         information in the event of any error(s).
       * ``log`` - a log of suite events, consisting of information about
         user interaction.
+      * ``file-installation-log`` - a log documenting the file installation 
+        process on the remote platform.
 
       The suite log directory lies within the :term:`run directory`:
 

--- a/src/suite-design-guide/general-principles.rst
+++ b/src/suite-design-guide/general-principles.rst
@@ -104,14 +104,15 @@ files they need are more robust.
 Installing Files At Start-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Files can be installed on any remote platforms. As standard, Cylc installs the
+Files can be installed on any remote platform. By default, Cylc installs the
 following directories: ``app``, ``bin``, ``etc``, ``lib``.
 Cylc supports adding custom directories and files to the file installation.
 
-E.g. dir1, dir2, file1, file2, you can add the following configuration to your
+If, for example, you wished to install directories ``dir1``, ``dir2``, and
+files ``file1``, ``file2``, add the following configuration to your
 :cylc:conf:`flow.cylc`, under the section
 :cylc:conf:flow.cylc[scheduler]install.
-To denote a directory, please add a trailing slash.
+To mark an item as a directory, add a trailing slash.
 
 .. code-block:: cylc
 
@@ -120,7 +121,7 @@ To denote a directory, please add a trailing slash.
 
 .. note::
 
-   Please ensure files and directories to be installed are located in the top
+   Ensure files and directories to be installed are located in the top
    level of your workflow.
 
 The file installation will timeout after 10 minutes.

--- a/src/suite-design-guide/general-principles.rst
+++ b/src/suite-design-guide/general-principles.rst
@@ -104,9 +104,24 @@ files they need are more robust.
 Installing Files At Start-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use ``rose suite-run`` *file creation mode* or ``R1``
-install tasks to copy files to the self-contained suite run directory at
-start-up. Install tasks are preferred for time-consuming installations because
+Files can be installed on the remote platform. As standard, Cylc installs the
+following directories: ``app``, ``bin``, ``etc``, ``lib``.
+Cylc supports adding custom directories and files to the file installation.
+E.g. dir1, dir2, file1, file2, you can add the following configuration to your
+:cylc:conf:`flow.cylc`. To denote a directory, please add a trailing slash.  
+
+.. code-block:: cylc
+
+    [scheduler]
+        install = dir1/, dir2/, file1, file2
+
+.. note::
+
+   Please ensure files and directories to be installed are located in the top
+   level of your workflow. 
+
+The file installation will timeout after 10 minutes.
+Install tasks are preferred for time-consuming installations because
 they don't slow the suite start-up process, they can be monitored,
 they can run directly on target platforms, and you can rerun them later without
 restarting the suite. If you are using symbolic links to install files under

--- a/src/suite-design-guide/general-principles.rst
+++ b/src/suite-design-guide/general-principles.rst
@@ -104,11 +104,14 @@ files they need are more robust.
 Installing Files At Start-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Files can be installed on the remote platform. As standard, Cylc installs the
+Files can be installed on any remote platforms. As standard, Cylc installs the
 following directories: ``app``, ``bin``, ``etc``, ``lib``.
 Cylc supports adding custom directories and files to the file installation.
+
 E.g. dir1, dir2, file1, file2, you can add the following configuration to your
-:cylc:conf:`flow.cylc`. To denote a directory, please add a trailing slash.  
+:cylc:conf:`flow.cylc`, under the section
+:cylc:conf:flow.cylc[scheduler]install.
+To denote a directory, please add a trailing slash.
 
 .. code-block:: cylc
 
@@ -118,7 +121,7 @@ E.g. dir1, dir2, file1, file2, you can add the following configuration to your
 .. note::
 
    Please ensure files and directories to be installed are located in the top
-   level of your workflow. 
+   level of your workflow.
 
 The file installation will timeout after 10 minutes.
 Install tasks are preferred for time-consuming installations because

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -1269,6 +1269,8 @@ The information logged here includes:
 - Suite stalled warnings.
 - Client commands (e.g. ``cylc hold``)
 - Job IDs.
+- Information relating to the remote file installation, contained in a
+  separate log file, the ``file-installation-log``.
 
 .. note::
 

--- a/src/user-guide/writing-suites/configuration.rst
+++ b/src/user-guide/writing-suites/configuration.rst
@@ -173,11 +173,13 @@ WebStorm
 Gross File Structure
 ^^^^^^^^^^^^^^^^^^^^
 
-Cylc :cylc:conf:`flow.cylc` files consist of a suite title and description followed by
-configuration items grouped under several top level section headings:
+Cylc :cylc:conf:`flow.cylc` files consist of configuration items grouped under
+several top level section headings:
 
+:cylc:conf:`[meta]`
+   Information about the workflow e.g. title and description.
 :cylc:conf:`[scheduler]`
-   Non task-specific suite configuration.
+   Non task-specific workflow configuration.
 :cylc:conf:`[scheduling]`
    Determines when tasks are ready to run.
 


### PR DESCRIPTION
Just a quick initial update to the docs to include the file installation work. There will be more updates needed for rose-suite-run migration after symlink work is completed.
