### PR TITLE
Deprecate `max active cycle points` in favor of `runahead limit`

### DIFF
--- a/src/suite-design-guide/general-principles.rst
+++ b/src/suite-design-guide/general-principles.rst
@@ -332,7 +332,7 @@ queues*, respectively.
 Runahead Limiting
 ^^^^^^^^^^^^^^^^^
 
-By default Cylc allows a maximum of three cycle points to be active at the same
+By default Cylc allows a maximum of five cycle points to be active at the same
 time, but this value is configurable:
 
 .. code-block:: cylc
@@ -340,7 +340,7 @@ time, but this value is configurable:
    [scheduling]
        initial cycle point = 2020-01-01T00
        # Don't allow any cycle interleaving:
-       max active cycle points = 1
+       runahead limit = P1
 
 
 Internal Queues

--- a/src/suites/satellite/ext-trigger/flow.cylc
+++ b/src/suites/satellite/ext-trigger/flow.cylc
@@ -31,8 +31,7 @@
     cycling mode = integer
     initial cycle point = 1
     final cycle point = {{N_DATASETS}}
-    max active cycle points = 5
-    # runahead limit = P5 # (alternative limiting method)
+    runahead limit = P5
     [[special tasks]]
         external-trigger = get_data("new dataset ready for processing")
     [[graph]]

--- a/src/suites/xtrigger/xrandom/flow.cylc
+++ b/src/suites/xtrigger/xrandom/flow.cylc
@@ -2,8 +2,7 @@
     cycling mode = integer
     initial cycle point = 1
     final cycle point = 5
-    max active cycle points = 5
-    spawn to max active cycle points = True
+    runahead limit = P5
     [[xtriggers]]
         # Called once for all dependent tasks (all cycles).
         x1 = xrandom(percent=25, secs=2):PT5S

--- a/src/tutorial/furthertopics/suicide-triggers.rst
+++ b/src/tutorial/furthertopics/suicide-triggers.rst
@@ -216,14 +216,15 @@ either succeeded or failed Cylc cannot move onto the next cycle.
 
 .. tip::
 
-   For more information search ``max active cycle points`` in the
+   For more information search ``runahead limit`` in the
    `Cylc User Guide`_.
 
 You will also notice that some of the tasks (e.g. ``eat_cake`` in cycle ``2``
 in the above example) are drawn in a faded gray. This is because these tasks
 have not yet been run in earlier cycles and as such cannot run.
 
-.. TODO - Spawn On Demand!
+.. TODO - Spawn On Demand! (Also the default runahead limit on cycle points has
+   increased to 5)
 
 
 Removing Tasks From The Graph

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -256,9 +256,9 @@ Authentication Files
 Cylc uses `CurveZMQ <http://curvezmq.org/page:read-the-docs/>`_ to ensure that
 any data, sent between the :term:`scheduler <scheduler>` and the client,
 remains protected during transmission. Public keys are used to encrypt the
-data, private keys for decryption. 
+data, private keys for decryption.
 
-Authentication files will be created in your 
+Authentication files will be created in your
 ``$HOME/cylc-run/WORKFLOW/.service/`` directory at start-up. You can expect to
 find one client public key per file system for remote jobs.
 
@@ -498,12 +498,10 @@ suites. Succeeded and failed tasks are ignored when computing the runahead
 limit.
 
 The preferred runahead limiting mechanism restricts the number of consecutive
-active cycle points. The default value is three active cycle points, this
-is configured by :cylc:conf:`[scheduling]max active cycle points`.
-
-Alternatively the interval between the
-slowest and fastest tasks can be specified as hard limit by configuring
-:cylc:conf:`[scheduling]runahead limit`.
+active cycle points. The default value is five active cycle points, this
+is configured by :cylc:conf:`[scheduling]runahead limit`. Alternatively, the
+time interval between the slowest and fastest tasks can be specified (for
+:term:`datetime cycling` workflows).
 
 
 .. _InternalQueues:


### PR DESCRIPTION
Twinned with https://github.com/cylc/cylc-flow/pull/3848