### PR TITLE
GH Actions: Use looser actions version pinning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@
 
 # Deploy a new version of the documentation or rebuild an existing one.
 
-# Note: All changes made to the gh-pages branch are non-destructive 
+# Note: All changes made to the gh-pages branch are non-destructive
 #       (i.e. no force pushing) so all changes can be undone.
 
 name: deploy
@@ -35,6 +35,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: configure python
         uses: actions/setup-python@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: configure python
         uses: actions/setup-python@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.7'
 
       - name: checkout cylc-doc
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2
         with:
           ref: master
           path: docs
@@ -52,7 +52,7 @@ jobs:
           pip install "${{ github.workspace }}/docs[all]"
 
       - name: checkout cylc-flow
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2
         with:
           repository: cylc/cylc-flow
           ref: master
@@ -65,7 +65,7 @@ jobs:
           pip install './cylc-flow[all]'
 
       - name: checkout gh-pages branch
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.7'
 
       - name: configure node
-        uses: actions/setup-node@v1.4.2
+        uses: actions/setup-node@v1
         with:
             node-version: '10.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: configure python
         uses: actions/setup-python@v2

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -16,7 +16,7 @@
 
 # Remove a deployed version of the documentation.
 
-# Note: All changes made to the gh-pages branch are non-destructive 
+# Note: All changes made to the gh-pages branch are non-destructive
 #       (i.e. no force pushing) so all changes can be undone.
 
 name: undeploy
@@ -31,6 +31,7 @@ on:
 jobs:
   undeploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: configure python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Fix test failures e.g. https://github.com/cylc/cylc-doc/pull/172/checks?check_run_id=1453710034

Do
```
- uses: actions/setup-node@v1
```
instead of
```
- uses: actions/setup-node@v1.4.2
```
because they update the tag `v1` to point to the latest `v1.x` release