### PR TITLE
first go at revised clock-trigger tutorial

### DIFF
--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -3,11 +3,6 @@
 Clock Triggered Tasks
 =====================
 
-.. TODO
-
-   After #2423 has been finalised and merged this tutorial should be
-   re-factored / re-written to incorporate the usage of ``cylc-graph``.
-
 In a :term:`datetime cycling` suite the time represented by the
 :term:`cycle points <cycle point>` bear no relation to the real-world time.
 Using clock-triggers we can make tasks wait until their cycle point time before
@@ -15,6 +10,11 @@ running.
 
 Clock-triggering effectively enables us to tether the "cycle time" to the
 "real world time" which we refer to as the :term:`wall-clock time`.
+
+.. note::
+
+   Clock triggers are :ref:`Section External Triggers`. They differ from
+   custom external triggers only in that they are provided with Cylc.
 
 
 Clock Triggering
@@ -25,7 +25,7 @@ When clock-triggering tasks we can use different
 
 .. code-block:: cylc
 
-   clock-trigger = taskname(CYCLE_OFFSET)
+   my_clock_trigger = wall_clock(offset=<iso8601 duration>)
 
 .. note::
 
@@ -44,11 +44,11 @@ Within your ``~/cylc-run`` directory create a new directory called
    mkdir ~/cylc-run/clock-trigger
    cd ~/cylc-run/clock-trigger
 
-Paste the following code into a :cylc:conf:`flow.cylc` file:
+Paste the following code into a ``flow.cylc`` file:
 
 .. code-block:: cylc
 
-   [scheduler]
+   [cylc]
        UTC mode = True # Ignore DST
 
    [scheduling]
@@ -74,8 +74,8 @@ Run your suite using::
 
    cylc run clock-trigger
 
-Stop the suite after a few cycles using the :guilabel:`stop` button in the
-``cylc gui``. Notice how the tasks run as soon as possible rather than
+Stop the suite after a few cycles using ``cylc stop --now --now clock-trigger``.
+Notice how the tasks run as soon as possible rather than
 waiting for the actual time to be equal to the cycle point.
 
 
@@ -85,13 +85,12 @@ Clock-Triggering Tasks
 We want our clock to only ring in real-time rather than the simulated
 cycle time.
 
-To do this, add the following lines to the ``[scheduling]`` section of
-your :cylc:conf:`flow.cylc`:
+To do this, modify the ``[scheduling][graph]`` section of
+your ``flow.cylc``:
 
 .. code-block:: cylc
 
-   [[special tasks]]
-       clock-trigger = bell(PT0M)
+   PT1H = @wall_clock  => bell
 
 This tells the suite to clock trigger the ``bell`` task with a cycle
 offset of ``0`` hours.
@@ -115,10 +114,11 @@ real-time. Thus, when the wall-clock time caught up with the cycle time, the
 Adding More Clock-Triggered Tasks
 ---------------------------------
 
+Running clock triggered tests at the cycle time is a special case:
 We will now modify our suite to run tasks at quarter-past, half-past and
 quarter-to the hour.
 
-Open your :cylc:conf:`flow.cylc` and modify the ``[runtime]`` section by adding the
+Open your ``flow.cylc`` and modify the ``[runtime]`` section by adding the
 following:
 
 .. code-block:: cylc
@@ -130,15 +130,17 @@ Edit the ``[[scheduling]]`` section to read:
 
 .. code-block:: cylc
 
-   [[special tasks]]
-       clock-trigger = bell(PT0M), quarter_past(PT15M), half_past(PT30M), quarter_to(PT45M)
+   [[xtriggers]]
+       quarter_past_trigger = wall_clock(offset=PT15M):PT30S
+       half_past_trigger = wall_clock(offset=PT30M):PT30S
+       quarter_to_trigger = wall_clock(offset=PT45M):PT30S
    [[graph]]
        PT1H = """
-               bell
-               quarter_past
-               half_past
-               quarter_to
-           """
+           @wall_clock => bell
+           @quarter_past_trigger => quarter_past
+           @half_past_trigger => half_past
+           @quarter_to_trigger => quarter_to
+       """
 
 Note the different values used for the cycle offsets of the clock-trigger tasks.
 
@@ -157,13 +159,22 @@ Leave your suite running for a while to confirm it is working as expected
 and then shut it down using the :guilabel:`stop` button in the ``cylc gui``.
 
 
+.. note::
+
+   You may have noticed the ``:PT30S`` at the end of each clock trigger
+   definition. This how often the :ref:`Section External Triggers` is checked.
+   By default external triggers are checked every 10 seconds, but if there
+   are a lot of external triggers this can be hard work for the computer
+   running the workflow and it may not be necessary to check this often. 
+
+
 Summary
 -------
 
 * Clock triggers are a type of :term:`dependency` which cause
   :term:`tasks <task>` to wait for the :term:`wall-clock time` to reach the
   :term:`cycle point` time.
-* A clock trigger applies only to a single task.
+* Clock triggers are a built in example of :ref:`Section External Triggers`.
 * Clock triggers can only be used in datetime cycling suites.
 
 For more information see the `Cylc User Guide`_.

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -48,7 +48,7 @@ Paste the following code into a ``flow.cylc`` file:
 
 .. code-block:: cylc
 
-   [cylc]
+   [scheduler]
        UTC mode = True # Ignore DST
 
    [scheduling]


### PR DESCRIPTION
Should Close #61 
Questions:
- I'm I emphasizing that clock triggers are a special case of xtriggers (gateway). Good Idea?
- I don't go into specifics or much detail about `my_trigger = wall_clock(offset=PT0H):<ISOdatetime freq>`. Should I?