### PR TITLE
Basic platforms fix

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -282,23 +282,22 @@ for use with Cylc and don't source unwanted systems or echo to stdout.
    .. code-block:: cylc
 
       [scheduler]
-         cycle point format = %Y
-         [[parameters]]
-            m = 0..5
-            n = 0..2
+          cycle point format = %Y
+          [[parameters]]
+              m = 0..5
+              n = 0..2
       [scheduling]
-         initial cycle point = 3000
-         [[graph]]
-            P1Y = "foo[-P1Y] => foo => bar<m> => qux<m,n> => waz"
+          initial cycle point = 3000
+          [[graph]]
+              P1Y = "foo[-P1Y] => foo => bar<m> => qux<m,n> => waz"
       [runtime]
-         [[root]]
-            script = """
-               sleep 20
-               # fail 50% of the time if try number is less than 5
-               if (( CYLC_TASK_TRY_NUMBER < 5 )); then
-                 if (( RANDOM % 2 < 1 )); then
-                    exit 1
-                 fi
-               fi"""
-            [[[job]]]
-               execution retry delays = 6*PT2S
+          [[root]]
+              script = """
+                  sleep 20
+                  # fail 50% of the time if try number is less than 5
+                  if (( CYLC_TASK_TRY_NUMBER < 5 )); then
+                      if (( RANDOM % 2 < 1 )); then
+                          exit 1
+                      fi
+                  fi"""
+              execution retry delays = 6*PT2S

--- a/src/suite-design-guide/general-principles.rst
+++ b/src/suite-design-guide/general-principles.rst
@@ -606,14 +606,12 @@ graph:
            script = run-model.sh
        [[long_fc]]
            inherit = MODEL
-           [[[job]]]
-               execution time limit = PT30M
+           execution time limit = PT30M
            [[[environment]]]
                RUN_LEN = PT48H
        [[short_fc]]
            inherit = MODEL
-           [[[job]]]
-               execution time limit = PT10M
+           execution time limit = PT10M
            [[[environment]]]
                RUN_LEN = PT12H
 
@@ -652,8 +650,7 @@ times at 1 minute intervals, then another 5 times at 1 hour intervals:
 
    [runtime]
        [[HPC]]  # Inherited by all jobs submitted to HPC.
-           [[[job]]]
-               submission retry delays = 10*PT1M, 5*PT1H
+           submission retry delays = 10*PT1M, 5*PT1H
 
 
 Job Execution Retries
@@ -678,8 +675,7 @@ then an automatic retry may be appropriate:
                fi
                model.exe
            """
-           [[[job]]]
-               execution retry delays = 1*PT0M
+           execution retry delays = 1*PT0M
 
 
 Failure Recovery Workflows

--- a/src/suite-design-guide/portable-suites.rst
+++ b/src/suite-design-guide/portable-suites.rst
@@ -64,8 +64,7 @@ For example, this task definition:
    [runtime]
        [[foo]]
            script = run-foo.sh
-           [[[remote]]]
-               host = hpc1.niwa.co.nz
+           platform = niwa_hpc
 
 can equally be written like this:
 
@@ -76,8 +75,7 @@ can equally be written like this:
            script = run-foo.sh
    [runtime]  # Part 2 (site-specific).
        [[foo]]
-           [[[remote]]]
-               host = hpc1.niwa.co.nz
+           platform = niwa_hpc
 
 .. note::
 
@@ -112,8 +110,7 @@ where the site include-file ``site/niwa.cylc`` contains:
    # site/niwa.cylc
    [runtime]
        [[foo]]
-           [[[remote]]]
-               host = hpc1.niwa.co.nz
+           platform = niwa_hpc
 
 
 Site-Specific Graphs
@@ -191,13 +188,11 @@ mess) and it exposes all site configuration to all users:
            script = run-model.sh
    {# Site switch blocks not recommended:#}
    {% if SITE == 'niwa' %}
-           [[[job]]]
-               batch system = loadleveler
+           platform = niwa_loadleveler_platform
            [[[directives]]]
                # NIWA Loadleveler directives...
    {% elif SITE == 'metoffice' %}
-           [[[job]]]
-               batch system = pbs
+           platform = metoffice_pbs_platform
            [[[directives]]]
                # Met Office PBS directives...
    {% elif SITE == ... %}
@@ -334,10 +329,7 @@ and batch scheduler directives.
        [[root]]
            script = rose task-run -v
        [[HPC]]  # NIWA job host and batch scheduler settings.
-           [[[remote]]]
-               host = hpc1.niwa.co.nz
-           [[[job]]]
-               batch system = loadleveler
+           platform = niwa_loadleveler_platform
            [[[directives]]]
                account_no = NWP1623
                class = General
@@ -408,10 +400,7 @@ and ``site/niwa.cylc``:
            P1D = postproc => upload_niwa
    [runtime]
        [[HPC]]
-           [[[remote]]]
-               host = hpc1.niwa.co.nz
-           [[[job]]]
-               batch system = loadleveler
+           platform = niwa_loadleveler_platform
            [[[directives]]]
                account_no = NWP1623
                class = General

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -87,8 +87,7 @@ to the end of the ``[[roll_doubles]]`` task section in the :cylc:conf:`flow.cylc
 
 .. code-block:: cylc
 
-   [[[job]]]
-       execution retry delays = 5*PT6S
+   execution retry delays = 5*PT6S
 
 This means that if the ``roll_doubles`` task fails, Cylc expects to
 retry running it 5 times before finally failing. Each retry will have

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -59,16 +59,15 @@ Job Submission
 
    By default Cylc runs :term:`jobs <job>` on the machine where the suite is
    running. We can tell Cylc to run jobs on other machines by setting the
-   ``[remote]host`` setting to the name of the host, e.g. to run a task on the
-   host ``computehost`` you might write:
+   ``platform`` setting: If, for example you want to run a task job on a
+   platform called ``powerful_computer`` you would write:
 
 .. code-block:: cylc
 
    [runtime]
        [[hello_computehost]]
            script = echo "Hello Compute Host"
-           [[[remote]]]
-               host = computehost
+           platform = powerful_computer
 
 .. _background processes: https://en.wikipedia.org/wiki/Background_process
 .. _job scheduler: https://en.wikipedia.org/wiki/Job_scheduler
@@ -107,12 +106,7 @@ Job Submission
            script = big-executable
 
            # Submit to the host "big-computer".
-           [[[remote]]]
-               host = big-computer
-
-           # Submit the job using the "slurm" job runner.
-           [[[job]]]
-               batch system = slurm
+           platform = big_computer_platform_with_job_runner
 
            # Inform "slurm" that this job requires 500MB of RAM and 4 CPUs.
            [[[directives]]]
@@ -135,8 +129,7 @@ Timeouts
    [runtime]
        [[some_task]]
            script = some-executable
-           [[[job]]]
-               execution time limit = PT15M  # 15 minutes.
+           execution time limit = PT15M  # 15 minutes.
 
 
 Retries
@@ -161,8 +154,8 @@ Sometimes jobs fail. This can be caused by two factors:
 .. ifnotslides::
 
    In the event of failure Cylc can automatically re-submit (retry) jobs. We
-   configure retries using the ``[job]execution retry delays`` and
-   ``[job]submission retry delays`` settings. These settings are both set to an
+   configure retries using the ``execution retry delays`` and
+   ``submission retry delays`` settings. These settings are both set to an
    :term:`ISO8601 duration`, e.g. setting ``execution retry delays`` to ``PT10M``
    would cause the job to retry every 10 minutes in the event of execution
    failure.
@@ -175,14 +168,15 @@ Sometimes jobs fail. This can be caused by two factors:
    [runtime]
        [[some-task]]
            script = some-script
-           [[[job]]]
-               # In the event of execution failure, retry a maximum
-               # of three times every 15 minutes.
-               execution retry delays = 3*PT15M
-               # In the event of submission failure, retry a maximum
-               # of two times every ten minutes and then every 30
-               # minutes thereafter.
-               submission retry delays = 2*PT10M, PT30M
+
+           # In the event of execution failure, retry a maximum
+           # of three times every 15 minutes.
+           execution retry delays = 3*PT15M
+
+           # In the event of submission failure, retry a maximum
+           # of two times every ten minutes and then every 30
+           # minutes thereafter.
+           submission retry delays = 2*PT10M, PT30M
 
 
 Start, Stop, Restart

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -59,7 +59,7 @@ Job Submission
 
    By default Cylc runs :term:`jobs <job>` on the machine where the suite is
    running. We can tell Cylc to run jobs on other machines by setting the
-   ``platform`` setting: If, for example you want to run a task job on a
+   :term:`platform` setting: If, for example you want to run a task job on a
    platform called ``powerful_computer`` you would write:
 
 .. code-block:: cylc

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -395,12 +395,12 @@ repeatedly until finished:
 
    [runtime]
        [[foo]]
-           [[[job]]]
-               # poll every minute in the 'submitted' state:
-               submission polling intervals = PT1M
-               # poll one minute after foo starts running, then every 10
-               # minutes for 50 minutes, then every minute until finished:
-               execution polling intervals = PT1M, 5*PT10M, PT1M
+           # poll every minute in the 'submitted' state:
+           submission polling intervals = PT1M
+
+           # poll one minute after foo starts running, then every 10
+           # minutes for 50 minutes, then every minute until finished:
+           execution polling intervals = PT1M, 5*PT10M, PT1M
 
 .. cylc-scope:: global.cylc[platforms][<platform name>]
 
@@ -627,10 +627,9 @@ this case.) E.g. to send an email on (submission) failed and retry:
                test ${CYLC_TASK_TRY_NUMBER} -eq 3
                cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'oopsy daisy'
            """
+           execution retry delays = PT0S, PT30S
            [[[events]]]
                mail events = submission failed, submission retry, failed, retry, oops
-           [[[job]]]
-               execution retry delays = PT0S, PT30S
            [[[outputs]]]
                oops = oopsy daisy
 
@@ -734,11 +733,10 @@ event handlers using the alternate methods:
    [runtime]
        [[foo]]
            script = test ${CYLC_TASK_TRY_NUMBER} -eq 2
+           execution retry delays = PT0S, PT30S
            [[[events]]]
                retry handler = "echo '!!!!!EVENT!!!!!' "
                failed handler = "echo '!!!!!EVENT!!!!!' "
-           [[[job]]]
-               execution retry delays = PT0S, PT30S
 
 .. code-block:: cylc
 
@@ -748,12 +746,11 @@ event handlers using the alternate methods:
                test ${CYLC_TASK_TRY_NUMBER} -eq 2
                cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'oopsy daisy'
            """
+           execution retry delays = PT0S, PT30S
            [[[events]]]
                handlers = "echo '!!!!!EVENT!!!!!' "
                # Note: task output name can be used as an event in this method
                handler events = retry, failed, oops
-           [[[job]]]
-               execution retry delays = PT0S, PT30S
            [[[outputs]]]
                oops = oopsy daisy
 

--- a/src/user-guide/task-implementation.rst
+++ b/src/user-guide/task-implementation.rst
@@ -248,5 +248,4 @@ task to repeatedly poll for the results of the detached processes:
            # Fail and retry every minute (for 10 tries at the most) if model's
            # job.done indicator file does not exist yet.
            script = "[[ ! -f $RUN_DIR/job.done ]] && exit 1"
-           [[[job]]]
-               execution retry delays = 10 * PT1M
+           execution retry delays = 10 * PT1M

--- a/src/user-guide/task-job-submission.rst
+++ b/src/user-guide/task-job-submission.rst
@@ -157,7 +157,7 @@ Overriding The Job Submission Command
 
 To change the form of the actual command used to submit a job you
 need to define a new 
-:cylc:conf:`global.cylc[platform][<namespace>]job runner command template`.
+:cylc:conf:`global.cylc[platform][<platform name>]job runner command template`.
 
 .. code-block:: cylc
 
@@ -190,7 +190,7 @@ Tasks can be polled on demand by using the
 
 Tasks are polled automatically, once, if they timeout while queueing in a
 job runner and submission timeout is set.
-(See :cylc:conf:`[runtime][<namespace>][events]`
+(See :cylc:conf:`[runtime][<task name>][events]`
 for how to configure timeouts).
 
 Tasks are polled multiple times, where necessary, when they exceed their
@@ -220,8 +220,8 @@ The default polling intervals can be overridden in the global configuration:
 Or in suite configurations (in which case polling will be done regardless
 of the communication method configured for the platform):
 
-* :cylc:conf:`submission polling intervals<[runtime][<namespace>]submission polling intervals>`
-* :cylc:conf:`execution polling intervals<[runtime][<namespace>]execution polling intervals>`
+* :cylc:conf:`submission polling intervals<[runtime][<task name>]submission polling intervals>`
+* :cylc:conf:`execution polling intervals<[runtime][<task name>]execution polling intervals>`
 
 Note that regular polling is not as efficient as task messaging in updating
 task status, and it should be used sparingly in large suites.
@@ -249,7 +249,7 @@ Tasks can be killed on demand by using the ``cylc kill`` command.
 Execution Time Limit
 --------------------
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>]
+.. cylc-scope:: flow.cylc[runtime][<task name>]
 
 You can specify an :cylc:conf:`execution time limit` for all supported job
 submission methods. E.g.:
@@ -279,7 +279,7 @@ exceeds its :cylc:conf:`execution time limit`.)
 Execution Time Limit and Execution Timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>]
+.. cylc-scope:: flow.cylc[runtime][<task name>]
 
 If you specify an :cylc:conf:`execution time limit` the
 execution timeout event handler will only be called if the job has

--- a/src/user-guide/task-job-submission.rst
+++ b/src/user-guide/task-job-submission.rst
@@ -190,7 +190,7 @@ Tasks can be polled on demand by using the
 
 Tasks are polled automatically, once, if they timeout while queueing in a
 job runner and submission timeout is set.
-(See :cylc:conf:`[runtime][<task name>][events]`
+(See :cylc:conf:`[runtime][<namespace>][events]`
 for how to configure timeouts).
 
 Tasks are polled multiple times, where necessary, when they exceed their
@@ -220,8 +220,8 @@ The default polling intervals can be overridden in the global configuration:
 Or in suite configurations (in which case polling will be done regardless
 of the communication method configured for the platform):
 
-* :cylc:conf:`submission polling intervals<[runtime][<task name>]submission polling intervals>`
-* :cylc:conf:`execution polling intervals<[runtime][<task name>]execution polling intervals>`
+* :cylc:conf:`submission polling intervals<[runtime][<platform name>]submission polling intervals>`
+* :cylc:conf:`execution polling intervals<[runtime][<platform name>]execution polling intervals>`
 
 Note that regular polling is not as efficient as task messaging in updating
 task status, and it should be used sparingly in large suites.
@@ -249,7 +249,7 @@ Tasks can be killed on demand by using the ``cylc kill`` command.
 Execution Time Limit
 --------------------
 
-.. cylc-scope:: flow.cylc[runtime][<task name>]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 You can specify an :cylc:conf:`execution time limit` for all supported job
 submission methods. E.g.:
@@ -279,7 +279,7 @@ exceeds its :cylc:conf:`execution time limit`.)
 Execution Time Limit and Execution Timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cylc-scope:: flow.cylc[runtime][<task name>]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 If you specify an :cylc:conf:`execution time limit` the
 execution timeout event handler will only be called if the job has

--- a/src/user-guide/task-job-submission.rst
+++ b/src/user-guide/task-job-submission.rst
@@ -157,7 +157,7 @@ Overriding The Job Submission Command
 
 To change the form of the actual command used to submit a job you
 need to define a new 
-:cylc:conf:`global.cylc[platform][<platform name>]job runner command template`.
+:cylc:conf:`global.cylc[platforms][<platform name>]job runner command template`.
 
 .. code-block:: cylc
 
@@ -220,8 +220,8 @@ The default polling intervals can be overridden in the global configuration:
 Or in suite configurations (in which case polling will be done regardless
 of the communication method configured for the platform):
 
-* :cylc:conf:`submission polling intervals<[runtime][<platform name>]submission polling intervals>`
-* :cylc:conf:`execution polling intervals<[runtime][<platform name>]execution polling intervals>`
+* :cylc:conf:`submission polling intervals<[runtime][<namespace>]submission polling intervals>`
+* :cylc:conf:`execution polling intervals<[runtime][<namespace>]execution polling intervals>`
 
 Note that regular polling is not as efficient as task messaging in updating
 task status, and it should be used sparingly in large suites.

--- a/src/user-guide/writing-suites/jinja2.rst
+++ b/src/user-guide/writing-suites/jinja2.rst
@@ -224,8 +224,7 @@ Here's an example:
            R1 = OBS
    [runtime]
        [[OBS]]
-           [[[job]]]
-               batch system = pbs
+           platform = platform_using_pbs
        {% for i in obs_types %}
        [[ {{i}} ]]
            inherit = OBS

--- a/src/user-guide/writing-suites/runtime.rst
+++ b/src/user-guide/writing-suites/runtime.rst
@@ -389,53 +389,48 @@ evaluation on the task host.
 Remote Task Hosting
 -------------------
 
-.. TODO - platformise
+If a task declares a platform other than the platform running the workflow,
+Cylc will use non-interactive ssh to execute the task using the 
+:term:`job runner`: and one of the hosts from the platform definition
+(platforms are defined in the ``global.cylc`` file at site level).
 
-If a task declares an owner other than the suite owner and/or
-a host other than the suite host, Cylc will use non-interactive ssh to
-execute the task on the ``owner@host`` account by the configured
-:term:`job runner`:
+For example:
 
 .. code-block:: cylc
 
    [runtime]
        [[foo]]
-           [[[remote]]]
-               host = orca.niwa.co.nz
-               owner = bob
-           [[[job]]]
-               batch system = pbs
+           platform = orca
 
 For this to work:
 
-- Non-interactive ssh is required from the suite host to the remote
-  task accounts.
-- Cylc must be installed on task hosts.
+- Non-interactive ssh is required from the workflow platform to the remote
+  platform's hosts.
+- Cylc must be installed on the hosts of the destination platform.
 
   - If polling task communication is used, there is no other
     requirement.
   - If SSH task communication is configured, non-interactive ssh is
-    required from the task host to the suite host.
-  - If (default) task communication is configured, the task host
+    required from the task platform to the workflow platform.
+  - If (default) task communication is configured, the task platfom
     should have access to the port on the suite host.
 
 - The suite configuration directory, or some fraction of its
-  content, can be installed on the task host, if needed.
+  content, can be installed on the task platform, if needed.
 
-Tasks running on the suite host under another user account are treated as
-remote tasks.
-
-Remote hosting, like all namespace settings, can be declared globally in
+Platform, like all namespace settings, can be declared globally in
 the root namespace, or per family, or for individual tasks.
 
 
-Dynamic Host Selection
-^^^^^^^^^^^^^^^^^^^^^^
+Dynamic Platform Selection
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Instead of hardwiring host names into the suite configuration you can
-specify a shell command that prints a hostname, or an environment
-variable that holds a hostname, as the value of the
-:cylc:conf:`host config item <[runtime][<namespace>][remote]host>`.
+.. TODO - consider a re-write once dynamic platform selection done
+
+Instead of hardwiring platform names into the suite configuration you can
+specify a shell command that prints a platform name, or an environment
+variable that holds a platform name, as the value of the
+:cylc:conf:`host config item <[runtime][<namespace>]platform>`.
 
 
 Remote Task Log Directories


### PR DESCRIPTION
Some Platforms fixes for the documentation:
- [x] Fix all responses to `grep -rin --include "*.rst" --color "\[\[\[remote\]\]\]" -A 2 src/*` where there are platforms changes to be made.
- [x] Fix all responses to `grep -rin --include "*.rst" --color "\[\[\[job\]\]\]" -A 2 src/*`

I have not assumed that every return from these commands is wrong, but as it happens, they were.

This is not an attempt to fix _every_ _single_ _issue_ in the docs, but to chip a chunk of the out-of-date material.

Given that I'm going to be on holiday I recommend that reviewers add/modify this PR using suggestions.