### PR TITLE
document cylc rose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ on:
         description: 'Cylc Rose GitHub release tag'
         required: true
       metomi-rose-tag:
-        description: 'Rose GitHub release tag (currently only effects cylc-rose install)'
+        description: 'Rose GitHub release tag (currently only affects cylc-rose install)'
         required: true
       set_current:
         description: 'Make this the default documented version.'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,11 @@ name: deploy
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag present on both cylc-flow and cylc-docs.'
+      cylc-flow-tag:
+        description: 'Cylc Flow pypi release tag (must be present in cylc-docs)'
+        required: true
+      cylc-rose-tag:
+        description: 'Cylc Rose pypi release tag'
         required: true
       set_current:
         description: 'Make this the default documented version.'
@@ -45,7 +48,7 @@ jobs:
       - name: checkout cylc-doc
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.cylc-flow-tag }}
           path: docs
 
       - name: install graphviz
@@ -59,11 +62,12 @@ jobs:
           sudo apt-get install -y librsvg2-bin ghostscript
           pip install "${{ github.workspace }}/docs[all]"
 
-      - name: install cylc-flow
+      - name: install cylc and plugins
         run: |
           # NOTE: Install with [all] so we can import plugins which may
           #       have extra dependencies.
-          pip install "cylc-flow[all]==${{ github.event.inputs.tag }}"
+          pip install "cylc-flow[all]==${{ github.event.inputs.cylc-flow-tag }}"
+          pip install "cylc-rose[all]==${{ github.event.inputs.cylc-rose-tag }}"
 
       - name: checkout gh-pages
         uses: actions/checkout@v2
@@ -114,5 +118,5 @@ jobs:
         run: |
           cd gh-pages
           git add *
-          git commit -m "add: ${{ github.event.inputs.tag }}"
+          git commit -m "add: ${{ github.event.inputs.cylc-flow-tag }}"
           git push origin HEAD

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,13 @@ on:
   workflow_dispatch:
     inputs:
       cylc-flow-tag:
-        description: 'Cylc Flow pypi release tag (must be present in cylc-docs)'
+        description: 'Cylc Flow GitHub release tag (must be present in cylc-docs)'
         required: true
       cylc-rose-tag:
-        description: 'Cylc Rose pypi release tag'
+        description: 'Cylc Rose GitHub release tag'
+        required: true
+      metomi-rose-tag:
+        description: 'Rose GitHub release tag (currently only effects cylc-rose install)'
         required: true
       set_current:
         description: 'Make this the default documented version.'
@@ -62,12 +65,17 @@ jobs:
           sudo apt-get install -y librsvg2-bin ghostscript
           pip install "${{ github.workspace }}/docs[all]"
 
-      - name: install cylc and plugins
+      - name: install libs to document
         run: |
           # NOTE: Install with [all] so we can import plugins which may
           #       have extra dependencies.
-          pip install "cylc-flow[all]==${{ github.event.inputs.cylc-flow-tag }}"
-          pip install "cylc-rose[all]==${{ github.event.inputs.cylc-rose-tag }}"
+          pip install  \
+            'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow'\
+              '@${{ github.event.inputs.cylc-flow-tag }}' \
+            'metomi-rose[all] @ git+https://github.com/metomi/rose'\
+              '@${{ github.event.inputs.metomi-rose-tag }}' \
+            'cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@'\
+              '${{ github.event.inputs.cylc-rose-tag }}'
 
       - name: checkout gh-pages
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,31 +53,14 @@ jobs:
           sudo apt-get install -y librsvg2-bin ghostscript
           pip install "${{ github.workspace }}/docs[all]"
 
-      - name: checkout cylc-flow
-        uses: actions/checkout@v2
-        with:
-          repository: cylc/cylc-flow
-          ref: master
-          path: cylc-flow
-
-      - name: install cylc-flow
+      - name: install libs to document
         run: |
           # NOTE: Install with [all] so we can import plugins which may
           #       have extra dependencies.
-          pip install './cylc-flow[all]'
-
-      - name: checkout cylc-rose
-        uses: actions/checkout@v2
-        with:
-          repository: cylc/cylc-rose
-          ref: master
-          path: cylc-rose
-
-      - name: install cylc-rose
-        run: |
-          # NOTE: Install with [all] so we can import plugins which may
-          #       have extra dependencies.
-          pip install './cylc-rose[all]'
+          pip install  \
+            'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@master' \
+            'metomi-rose[all] @ git+https://github.com/metomi/rose@master' \
+            'cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@master'
 
       - name: checkout gh-pages branch
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,19 @@ jobs:
           #       have extra dependencies.
           pip install './cylc-flow[all]'
 
+      - name: checkout cylc-rose
+        uses: actions/checkout@v2
+        with:
+          repository: cylc/cylc-rose
+          ref: master
+          path: cylc-rose
+
+      - name: install cylc-rose
+        run: |
+          # NOTE: Install with [all] so we can import plugins which may
+          #       have extra dependencies.
+          pip install './cylc-rose[all]'
+
       - name: checkout gh-pages branch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,17 @@ jobs:
           (cd "$GITHUB_WORKSPACE/cylc-flow"; pip install .[all])
           rm -r cylc-flow  # don't lint or test cylc-flow
 
+      - name: checkout cylc-rose
+        uses: actions/checkout@v2
+        with:
+          repository: 'cylc/cylc-rose'
+          path: 'cylc-rose'
+
+      - name: install cylc-rose
+        run: |
+          (cd "$GITHUB_WORKSPACE/cylc-rose"; pip install .[all])
+          rm -r cylc-rose  # don't lint or test cylc-rose
+
       - name: checkout cylc-doc
         uses: actions/checkout@v2
       - name: install cylc-doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,34 +27,21 @@ jobs:
           sudo apt-get install -y graphviz pkg-config libgraphviz-dev
           pip install pygraphviz
 
-      - name: checkout cylc-flow
-        uses: actions/checkout@v2
-        with:
-          repository: 'cylc/cylc-flow'
-          path: 'cylc-flow'
-
-      - name: install cylc-flow
-        run: |
-          (cd "$GITHUB_WORKSPACE/cylc-flow"; pip install .[all])
-          rm -r cylc-flow  # don't lint or test cylc-flow
-
-      - name: checkout cylc-rose
-        uses: actions/checkout@v2
-        with:
-          repository: 'cylc/cylc-rose'
-          path: 'cylc-rose'
-
-      - name: install cylc-rose
-        run: |
-          (cd "$GITHUB_WORKSPACE/cylc-rose"; pip install .[all])
-          rm -r cylc-rose  # don't lint or test cylc-rose
-
       - name: checkout cylc-doc
         uses: actions/checkout@v2
       - name: install cylc-doc
         run: |
           sudo apt-get install -y librsvg2-bin ghostscript
           pip install .[all]
+
+      - name: install libs to document
+        run: |
+          # NOTE: Install with [all] so we can import plugins which may
+          #       have extra dependencies.
+          pip install  \
+            'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@master' \
+            'metomi-rose[all] @ git+https://github.com/metomi/rose@master' \
+            'cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@master'
 
       - name: install eslint
         run: |

--- a/src/index.rst
+++ b/src/index.rst
@@ -12,6 +12,7 @@ indefinitely.
    introduction/index
    tutorial/index
    user-guide/index
+   plugins/index
    suite-design-guide/index
    reference/index
    glossary

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ============
 

--- a/src/plugins/cylc-rose.rst
+++ b/src/plugins/cylc-rose.rst
@@ -1,0 +1,4 @@
+Cylc Rose
+=========
+
+.. automodule:: cylc.rose

--- a/src/plugins/index.rst
+++ b/src/plugins/index.rst
@@ -1,0 +1,11 @@
+Plugins
+=======
+
+Cylc supports plugins for providing additional functionality.
+
+The following are "core" plugins maintained by the Cylc team:
+
+.. toctree::
+   :maxdepth: 1
+
+   cylc-rose


### PR DESCRIPTION
Sibling: https://github.com/cylc/cylc-rose/pull/22

Document the Cylc Rose plugin within the Cylc docs.

Options considered:

* Document in Rose (`metomi.github.io/rose`)
  * Poor visibility.
  * Cylc Rose is more of a plugin to Cylc than it is to Rose.
* Document in-place (`cylc.org/cylc-rose`)
  * Poor visibility, won't appear in search results.
  * Nice and simple.
* Document in Cylc (`cylc.org/cylc-doc`)
  * Good visibility.
  * There will be other Cylc plugins to document alongside.

Decided to try and document from the cylc.rose package docstring within cylc-doc.

Contains one un-related change to add a Sphinx reference label to the install docs so they can be easily referenced from other projects via intersphinx.