### PR TITLE
Add "nightly.latest" link

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,15 +103,15 @@ jobs:
 
       - name: build docs
         run: |
-          build_name="nightly.$(isodatetime --utc -f %Y-%m-%d)"
           make -C docs \
             html \
             slides \
             linkcheck \
             SPHINXOPTS='-Wn' \
             SETCURRENT=false \
-            CYLC_VERSION="$build_name"
-          git -C gh-pages add "$build_name" 'versions.json'
+            BUILDDIR='doc/nightly' \
+            CYLC_VERSION="nightly.$(isodatetime --utc -f %Y-%m-%d)"
+          git -C gh-pages add 'nightly' 'versions.json'
 
       - name: push changes
         working-directory: gh-pages


### PR DESCRIPTION
Had this idea after always having to update the URL of my ever-open nightly cylc-doc browser tab.

It's like how https://cylc.github.io/cylc-doc/current links to the latest version of the docs, but for the nightly builds, so that https://cylc.github.io/cylc-doc/nightly.latest links to the latest successful nightly build.