### PR TITLE
Cylc play/pause

### DIFF
--- a/cylc/doc/etc/tutorial/cylc-forecasting-suite/.validate
+++ b/cylc/doc/etc/tutorial/cylc-forecasting-suite/.validate
@@ -18,7 +18,7 @@
 set -eux
 APIKEY="$(head --lines 1 ../api-keys)"
 FLOW_NAME="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)"
-cylc install --flow-name "$FLOW_NAME" --no-run-name .
+cylc install --flow-name "$FLOW_NAME" --no-run-name
 sed -i "s/DATAPOINT_API_KEY/$APIKEY/" "$HOME/cylc-run/$FLOW_NAME/flow.cylc"
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"
 cylc play --no-detach --abort-if-any-task-fails "$FLOW_NAME"

--- a/cylc/doc/etc/tutorial/runtime-introduction/.validate
+++ b/cylc/doc/etc/tutorial/runtime-introduction/.validate
@@ -17,7 +17,7 @@
 
 set -eux
 FLOW_NAME="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)"
-cylc install --flow-name "$FLOW_NAME" --no-run-name .
+cylc install --flow-name "$FLOW_NAME" --no-run-name
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"
 cylc play --no-detach --abort-if-any-task-fails "$FLOW_NAME"
 cylc clean "$FLOW_NAME"

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -199,7 +199,8 @@ Glossary
       * :term:`initial cycle point`
 
    start cycle point
-      The "start" :term:`cycle point` is where the :term:`scheduler` starts.
+      The start cycle point is the :term:`cycle point` where the
+      :term:`scheduler` :term:`starts <start>` running from.
 
       This may be before or after the :term:`initial cycle point`.
 
@@ -213,7 +214,8 @@ Glossary
       * :term:`initial cycle point`
 
    stop cycle point
-      The "stop" :term:`cycle point` is where the :term:`scheduler` shuts down.
+      The stop cycle point is the :term:`cycle point` at which the
+      :term:`scheduler` :term:`shuts down <shutdown>`.
 
       This may be before or after the :term:`final cycle point`.
 
@@ -224,7 +226,7 @@ Glossary
       * :ref:`start_stop_cycle_point`
       * :term:`cycle point`
       * :term:`start cycle point`
-      * :term:`initial cycle point`
+      * :term:`final cycle point`
 
    integer cycling
       An integer cycling suite is a :term:`cycling suite<cycling>` which has
@@ -662,9 +664,9 @@ Glossary
 
    start
    startup
-      When a :term:`suite` starts the Cylc :term:`scheduler` is
-      run. This program controls the suite and is what we refer to as
-      "running".
+      A start is when the Cylc :term:`scheduler` runs a freshly-installed
+      :term:`suite` runs for the first time. The scheduler is the program that
+      controls the suite and is what we refer to as "running".
 
       A suite start can be either :term:`cold <cold start>` or :term:`warm <warm
       start>` (cold by default).
@@ -681,21 +683,25 @@ Glossary
 
    cold start
       A cold start is one in which the :term:`suite` :term:`starts <start>`
-      from the :term:`initial cycle point`. This is the default behaviour of
-      ``cylc run``.
+      from the :term:`initial cycle point`. This is the default behaviour
+      of ``cylc play`` for a suite that hasn't been run before.
 
       See also:
 
+      * :term:`start`
       * :term:`warm start`
 
    warm start
-      In a :term:`cycling suite <cycling>`
-      a warm start is one in which the :term:`suite` :term:`starts <start>`
-      from a :term:`cycle point` after the :term:`initial cycle point`.
-      Tasks in cycles before this point as assumed to have succeeded.
+      In a :term:`cycling suite <cycling>`, a warm start
+      is one in which a :term:`suite` (that hasn't been run before)
+      :term:`starts <start>` from a :term:`start cycle point` that is after the
+      :term:`initial cycle point`. Tasks in cycles before this point are
+      treated as if they have succeeded.
 
       See also:
 
+      * :term:`start`
+      * :term:`start cycle point`
       * :term:`cold start`
 
    cylc-run directory
@@ -718,7 +724,7 @@ Glossary
 
    stop
    shutdown
-      When a :term:`suite` is shutdown the :term:`scheduler` is
+      When a :term:`suite` is shut down the :term:`scheduler` is
       stopped. This means that no further :term:`jobs <job>` will be submitted.
 
       By default Cylc waits for any submitted or running :term:`jobs <job>` to
@@ -732,17 +738,39 @@ Glossary
       * :term:`reload`
 
    restart
-      When a :term:`stopped <stop>` :term:`suite` is "restarted" Cylc will pick
+      When a :term:`stopped <stop>` :term:`suite` is restarted, Cylc will pick
       up where it left off. Cylc will detect any :term:`jobs <job>` which
       have changed state (e.g. succeeded) during the period in which the
-      :term:`suite` was :term:`shutdown`.
+      :term:`suite` was stopped.
+
+      A restart is the behaviour of ``cylc play`` for a suite that has been
+      previously run.
 
       See also:
 
       * :ref:`Restarting Suites`
       * :term:`start`
-      * :term:`Stop <stop>`
-      * :term:`Reload <reload>`
+      * :term:`stop`
+      * :term:`reload`
+
+   pause
+      Pausing a :term:`suite` prevents all submission of :term:`jobs <job>`.
+      However, any already submitted jobs will still run to completion.
+
+      See also:
+
+      * :term:`resume`
+
+   resume
+      When a :term:`paused <pause>` :term:`suite` is resumed, :term:`jobs <job>`
+      will be allowed to be submitted once again.
+
+      Resuming the workflow is the behaviour of ``cylc play`` for a paused (but
+      not :term:`stopped <stop>`) workflow.
+
+      See also:
+
+      * :term:`pause`
 
    reload
       Any changes made to the :cylc:conf:`flow.cylc` file whilst the suite is

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -664,12 +664,12 @@ Glossary
 
    start
    startup
-      A start is when the Cylc :term:`scheduler` runs a freshly-installed
-      :term:`suite` runs for the first time. The scheduler is the program that
+      A start is when the Cylc :term:`scheduler` runs a :term:`suite`
+      for the first time. The scheduler is the program that
       controls the suite and is what we refer to as "running".
 
-      A suite start can be either :term:`cold <cold start>` or :term:`warm <warm
-      start>` (cold by default).
+      A suite start can be either :term:`cold <cold start>` or
+      :term:`warm <warm start>` (cold by default).
 
       See also:
 
@@ -755,7 +755,8 @@ Glossary
 
    pause
       Pausing a :term:`suite` prevents all submission of :term:`jobs <job>`.
-      However, any already submitted jobs will still run to completion.
+      However, any already-running or submitted jobs will still run to
+      completion.
 
       See also:
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -795,6 +795,37 @@ Glossary
       * :ref:`Reloading Suites`
       * `Cylc User Guide`_
 
+   hold
+   held task
+   hold after cycle point
+      A :term:`task` can be held using ``cylc hold``, which prevents it from
+      submitting :term:`jobs <job>`.
+
+      It is also possible to set a "hold after cycle point"; all tasks after
+      this cycle point will be held.
+
+      .. note::
+
+         While similar to :term:`pausing a workflow <pause>`, holding a task(s)
+         is slightly different. Pausing a workflow does not hold tasks or
+         affect task states. Any held tasks are not :term:`released <release>`
+         when :term:`resuming <resume>` a paused workflow.
+
+      See also:
+
+      * :term:`release`
+
+   release
+      :term:`Held tasks <hold>` can be released using ``cylc release``,
+      allowing submission of :term:`jobs <job>` once again.
+
+      It is also possible to remove the "hold after cycle point" if set,
+      using ``cylc release --all``. This will also release all held tasks.
+
+      See also:
+
+      * :term:`hold`
+
    parameterisation
       Parameterisation is a way to consolidate configuration in the Cylc
       :cylc:conf:`flow.cylc` file by implicitly looping over a set of

--- a/src/tutorial/furthertopics/broadcast.rst
+++ b/src/tutorial/furthertopics/broadcast.rst
@@ -69,7 +69,7 @@ whilst the suite is running. For instance we could change the value of the
 Run the suite then try using the ``cylc broadcast`` command to change the
 message::
 
-   cylc run tutorial-broadcast
+   cylc play tutorial-broadcast
    cylc broadcast tutorial-broadcast -n announce -s "[environment]WORD=it"
 
 Inspect the ``share/knights`` file, you should see the message change at

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -72,11 +72,14 @@ of times equal to the (cycle point) hour.
 
 Run your suite using::
 
-   cylc run clock-trigger
+   cylc play clock-trigger
 
 Stop the suite after a few cycles using ``cylc stop --now --now clock-trigger``.
 Notice how the tasks run as soon as possible rather than
 waiting for the actual time to be equal to the cycle point.
+
+.. TODO - check this tutorial still works now that cylc run/restart has been
+   replaced by cylc play
 
 
 Clock-Triggering Tasks
@@ -146,7 +149,7 @@ Note the different values used for the cycle offsets of the clock-trigger tasks.
 
 Save your changes and run your suite using::
 
-   cylc run clock-trigger now
+   cylc play clock-trigger now
 
 .. note::
 
@@ -165,7 +168,7 @@ and then shut it down using the :guilabel:`stop` button in the ``cylc gui``.
    definition. This how often the :ref:`Section External Triggers` is checked.
    By default external triggers are checked every 10 seconds, but if there
    are a lot of external triggers this can be hard work for the computer
-   running the workflow and it may not be necessary to check this often. 
+   running the workflow and it may not be necessary to check this often.
 
 
 Summary

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -354,7 +354,7 @@ triggers another task bar and when fully completed triggers another task, baz.
 
       .. code-block:: bash
 
-         cylc run message-triggers
+         cylc play message-triggers
 
       Your suite should now run, the tasks should succeed.
 
@@ -439,4 +439,3 @@ triggers another task bar and when fully completed triggers another task, baz.
 
       Note that the second email automatically bundles the messages to prevent
       your inbox from being flooded.
-

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -64,7 +64,7 @@ You will now have a :cylc:conf:`flow.cylc` file that looks like this:
 Open the ``cylc gui`` then run the suite::
 
    cylc gui queues-tutorial &
-   cylc run queues-tutorial
+   cylc play queues-tutorial
 
 You will see that all the ``steak``, ``pasta``, and ``pizza`` tasks are run
 at once, swiftly followed by all the ``ice_cream``, ``cheesecake``,

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -70,7 +70,10 @@ Let's see what happens when we run the suite as it is. Open the ``cylc gui``::
 
 Then run the suite::
 
-   cylc run retries-tutorial
+   cylc play retries-tutorial
+
+.. TODO - check this tutorial still works now that cylc run/restart has been
+   replaced by cylc play
 
 Unless you're lucky, the suite should fail at the roll_doubles task.
 
@@ -112,7 +115,7 @@ If you closed it, re-open the ``cylc gui``::
 
 Re-run the suite::
 
-   cylc run retries-tutorial
+   cylc play retries-tutorial
 
 What you should see is Cylc retrying the ``roll_doubles`` task. Hopefully,
 it will succeed (there is only about a about a 1 in 3 chance of every task

--- a/src/tutorial/furthertopics/suicide-triggers.rst
+++ b/src/tutorial/furthertopics/suicide-triggers.rst
@@ -130,7 +130,7 @@ Paste the following code into the :cylc:conf:`flow.cylc` file:
 Open the ``cylc gui`` and run the suite::
 
    cylc gui suicide-triggers &
-   cylc run suicide-triggers
+   cylc play suicide-triggers
 
 The suite will run for three cycles then get stuck (because of the
 :cylc:conf:`[scheduling]runahead limit`).

--- a/src/tutorial/runtime/introduction.rst
+++ b/src/tutorial/runtime/introduction.rst
@@ -322,7 +322,6 @@ Running A Suite
 .. note::
 
    In this tutorial we are writing our suites in the ``cylc-run`` directory.
-.. TODO: rewrite based on new commands cylc install + cylc play
 
    It is possible to write them elsewhere on the system. If we do so we
    must install the workflow with ``cylc install`` before use. For more

--- a/src/tutorial/runtime/introduction.rst
+++ b/src/tutorial/runtime/introduction.rst
@@ -308,11 +308,11 @@ Running A Suite
    filesystem (so if we create a suite in ``~/cylc-run/foo`` we would put
    ``~/cylc-run/foo/flow.cylc``).
 
-   Next we can run the suite using the ``cylc run`` command.
+   Next we can run the suite using the ``cylc play`` command.
 
 .. code-block:: sub
 
-   cylc run <name>
+   cylc play <name>
 
 .. ifnotslides::
 
@@ -322,6 +322,7 @@ Running A Suite
 .. note::
 
    In this tutorial we are writing our suites in the ``cylc-run`` directory.
+.. TODO: rewrite based on new commands cylc install + cylc play
 
    It is possible to write them elsewhere on the system. If we do so we
    must install the workflow with ``cylc install`` before use. For more
@@ -419,7 +420,7 @@ Suite Files
 
       .. code-block:: bash
 
-         cylc run runtime-introduction
+         cylc play runtime-introduction
 
       The tasks will start to run - you should see them going through the
       "Waiting", "Running" and "Succeeded" states.

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -184,7 +184,7 @@ Start, Stop, Restart
 
 .. ifnotslides::
 
-   We have seen how to start and stop Cylc suites with ``cylc run`` and
+   We have seen how to start and stop Cylc suites with ``cylc play`` and
    ``cylc stop`` respectively. The ``cylc stop`` command causes Cylc to wait
    for all running jobs to finish before it stops the suite. There are two
    options which change this behaviour:
@@ -197,26 +197,26 @@ Start, Stop, Restart
       When the ``--now`` option is used twice Cylc stops straight away, leaving
       any jobs running.
 
-   Once a suite has stopped it is possible to restart it using the
-   ``cylc restart`` command. When the suite restarts it picks up where it left
+   Once a suite has stopped it is possible to restart it using
+   ``cylc play`` command. When the suite restarts it picks up where it left
    off and carries on as normal.
 
    .. code-block:: bash
 
       # Run the suite "name".
-      cylc run <name>
+      cylc play <name>
       # Stop the suite "name", killing any running tasks.
       cylc stop <name> --kill
       # Restart the suite "name", picking up where it left off.
-      cylc restart <name>
+      cylc play <name>
 
 .. ifslides::
 
    .. code-block:: sub
 
-      cylc run <name>
+      cylc play <name>
       cylc stop <name>
-      cylc restart <name>
+      cylc play <name>
 
       cylc stop <name> --kill
       cylc stop <name> --now --now
@@ -373,7 +373,7 @@ Start, Stop, Restart
 
       .. code-block:: bash
 
-         cylc run runtime-tutorial
+         cylc play runtime-tutorial
 
       If all goes well the suite will startup and the tasks will run and
       succeed. Note that the tasks which do not have a ``[runtime]`` section
@@ -441,7 +441,7 @@ Start, Stop, Restart
          * Pressing the play button in the Cylc GUI. Then, ensuring that
            "Cold Start" is selected within the dialogue window, pressing the
            "Start" button.
-         * Running the command ``cylc run runtime-tutorial``.
+         * Running the command ``cylc play runtime-tutorial``.
 
    #. **View The Forecast Summary.**
 

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -14,17 +14,18 @@ Suite Start-Up
 --------------
 
 There are three ways to start a suite running: *cold start* and *warm start*,
-which start from scratch; and *restart*, which starts from a prior
-suite state checkpoint. The only difference between cold starts and warm starts
-is that warm starts start from a point beyond the suite initial cycle point.
+which start from scratch; and *restart*, which continues from the prior
+suite state. The only difference between cold starts and warm starts
+is that warm starts start from a point beyond the initial cycle point.
 
-Once a suite is up and running it is typically a restart that is needed most
-often (but see also ``cylc reload``).
+Once a suite has been started, it cannot start from scratch again without a
+re-install. At this point, it is typically a restart that is needed most
+often (but see also :ref:`Reloading The Suite Configuration At Runtime`).
 
-.. warning::
+.. note::
 
-   Cold and warm starts wipe out prior suite state, so you can't go back to a
-   restart if you decide you made a mistake.
+   The ability to cold/warm start a previously-run suite was removed in Cylc 8.
+   This was because cold/warm starts would wipe out prior suite state.
 
 
 .. _Cold Start:
@@ -32,7 +33,7 @@ often (but see also ``cylc reload``).
 Cold Start
 ^^^^^^^^^^
 
-A cold start is the primary way to start a suite run from scratch:
+A cold start is the primary way to run a freshly-installed suite from scratch:
 
 .. code-block:: console
 
@@ -48,20 +49,17 @@ suite initial cycle point, or at the next valid point for the task.
 Warm Start
 ^^^^^^^^^^
 
-A warm start runs a suite from scratch like a cold start, but from the
-beginning of a given :term:`cycle point` that is beyond the suite
-:term:`initial cycle point`. This is generally inferior to a *restart* (which
-loads a previously recorded suite state - see :ref:`RestartingSuites`) because
-it may result in some tasks rerunning. However, a warm start may be required if
-a restart is not possible, e.g. because the suite run database was accidentally
-deleted. The warm start cycle point must be given on the command line:
+A warm start runs a freshly-installed suite from scratch, like a cold start,
+but from the beginning of a given :term:`start cycle point` that is beyond the
+suite :term:`initial cycle point`. The warm start cycle point must be given
+on the command line:
 
 .. code-block:: console
 
    $ cylc play SUITE --start-cycle-point=CYCLE_POINT
 
-The original suite initial cycle point is preserved, but all tasks and
-dependencies before the given warm start cycle point are ignored.
+The initial cycle point defined in :cylc:conf:`flow.cylc` is preserved, but
+all tasks and dependencies before the start cycle point are ignored.
 
 The scheduler starts by loading a first instance of each task at the warm
 start cycle point, or at the next valid point for the task.
@@ -117,9 +115,9 @@ would only run at cycle ``3``.
 Restart
 ^^^^^^^
 
-At restart (see ``cylc play --help``), the :term:`scheduler`
-initializes its task pool from the previous state at shutdown. This allows the
-suite to carry on exactly as it was just before being shut down or killed.
+At restart, the :term:`scheduler` initializes its task pool from the previous
+state at shutdown. This allows the suite to carry on exactly as it was just
+before being shut down or killed.
 
 .. code-block:: console
 
@@ -158,6 +156,8 @@ very difficult in general to automatically determine the cycle point of
 the first instance. Instead, the first instance of a new task should be
 inserted manually at the right cycle point, with ``cylc insert``.
 
+
+.. _Reloading The Suite Configuration At Runtime:
 
 Reloading The Suite Configuration At Runtime
 --------------------------------------------

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -13,10 +13,11 @@ to running suites.
 Suite Start-Up
 --------------
 
-There are three ways to start a suite running: *cold start* and *warm start*,
-which start from scratch; and *restart*, which continues from the prior
-suite state. The only difference between cold starts and warm starts
-is that warm starts start from a point beyond the initial cycle point.
+There are three ways to start a suite running:
+
+* Cold start: start from scratch
+* Warm start: start from scratch, but after the initial cycle point
+* Restart: continue from prior suite state
 
 Once a suite has been started, it cannot start from scratch again without a
 re-install. At this point, it is typically a restart that is needed most
@@ -33,7 +34,7 @@ often (but see also :ref:`Reloading The Suite Configuration At Runtime`).
 Cold Start
 ^^^^^^^^^^
 
-A cold start is the primary way to run a freshly-installed suite from scratch:
+A cold start is the primary way to run a suite for the first time:
 
 .. code-block:: console
 
@@ -43,13 +44,12 @@ The initial cycle point may be specified on the command line or in the :cylc:con
 file. The scheduler starts by loading the first instance of each task at the
 suite initial cycle point, or at the next valid point for the task.
 
-
 .. _Warm Start:
 
 Warm Start
 ^^^^^^^^^^
 
-A warm start runs a freshly-installed suite from scratch, like a cold start,
+A warm start runs a suite for the first time, like a cold start,
 but from the beginning of a given :term:`start cycle point` that is beyond the
 suite :term:`initial cycle point`. The warm start cycle point must be given
 on the command line:
@@ -1246,7 +1246,7 @@ Suite Run Databases
 -------------------
 
 Suite server programs maintain two ``sqlite`` databases to record
-certain aspects of run history:
+information on run history:
 
 .. code-block:: console
 
@@ -1334,8 +1334,8 @@ selective about that. (Also in a Rose suite, the ``flow.cylc`` file does not
 need to be restored if you restart with ``rose suite-run`` - which re-installs
 suite source files to the run directory).
 
-The public DB is not strictly required for a restart - the :term:`scheduler`
-will recreate it if needed.
+The public DB is not strictly required for a restart; if it is absent,
+the :term:`scheduler` will recreate it.
 
 The job status files are only needed if the suite state at last shutdown
 contained active tasks that now need to be polled to determine what happened to them

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -36,7 +36,7 @@ A cold start is the primary way to start a suite run from scratch:
 
 .. code-block:: console
 
-   $ cylc run SUITE [INITIAL_CYCLE_POINT]
+   $ cylc play SUITE
 
 The initial cycle point may be specified on the command line or in the :cylc:conf:`flow.cylc`
 file. The scheduler starts by loading the first instance of each task at the
@@ -58,7 +58,7 @@ deleted. The warm start cycle point must be given on the command line:
 
 .. code-block:: console
 
-   $ cylc run --warm SUITE [START_CYCLE_POINT]
+   $ cylc play SUITE --start-cycle-point=CYCLE_POINT
 
 The original suite initial cycle point is preserved, but all tasks and
 dependencies before the given warm start cycle point are ignored.
@@ -125,7 +125,7 @@ before being shut down or killed.
 
 .. code-block:: console
 
-   $ cylc restart SUITE
+   $ cylc play SUITE
 
 Tasks recorded in the "submitted" or "running" states are automatically polled
 (see :ref:`Task Job Polling`) at start-up to determine what happened to
@@ -956,13 +956,13 @@ should be used sparingly.
 The Meaning And Use Of Initial Cycle Point
 ------------------------------------------
 
-When a suite is started with the ``cylc run`` command (cold or
+When a suite is started with the ``cylc play`` command (cold or
 warm start) the cycle point at which it starts can be given on the command
-line or hardwired into the :cylc:conf:`flow.cylc` file:
+line or hardcoded into the :cylc:conf:`flow.cylc` file:
 
 .. code-block:: console
 
-   $ cylc run foo 20120808T06Z
+   $ cylc play foo --initial-cycle-point=20120808T06Z
 
 or:
 
@@ -1103,8 +1103,7 @@ Set the run mode (default ``live``) on the command line:
 
 .. code-block:: console
 
-   $ cylc run --mode=dummy SUITE
-   $ cylc restart --mode=dummy SUITE
+   $ cylc play --mode=dummy SUITE
 
 You can get specified tasks to fail in these modes, for more flexible suite
 testing. See cylc:conf:`[runtime][<namespace>][simulation]`.
@@ -1516,7 +1515,7 @@ does not finish until the sub-workflow does, and they should be non-cycling
 or have a ``final cycle point`` so they don't keep on running indefinitely.
 
 Sub-workflow names should normally incorporate the main-workflow cycle point (use
-``$CYLC_TASK_CYCLE_POINT`` in the ``cylc run`` command line to start the
+``$CYLC_TASK_CYCLE_POINT`` in the ``cylc play`` command line to start the
 sub-workflow), so that successive sub-workflows can run concurrently if necessary and
 do not compete for the same workflow run directory. This will generate a new
 sub-workflow run directory for every main-workflow cycle point, so you may want to

--- a/src/user-guide/running-suites.rst
+++ b/src/user-guide/running-suites.rst
@@ -24,9 +24,9 @@ often (but see also :ref:`Reloading The Suite Configuration At Runtime`).
 
 .. note::
 
-   The ability to cold/warm start a previously-run suite was removed in Cylc 8.
-   This was because cold/warm starts would wipe out prior suite state.
-
+   In Cylc 7 it was posssible to cold/warm start a suite without having to
+   reinstall it. In Cylc 8, you must reinstall the suite or remove its
+   database in order to cold/warm start it.
 
 .. _Cold Start:
 
@@ -127,11 +127,6 @@ Tasks recorded in the "submitted" or "running" states are automatically polled
 (see :ref:`Task Job Polling`) at start-up to determine what happened to
 them while the suite was down.
 
-.. note::
-
-   In Cylc 7, it was possible to restart a suite from "checkpoints" other than
-   the last shutdown state. However, this was removed in Cylc 8 as it was a
-   seldom-used feature.
 
 Behaviour of Tasks on Restart
 """""""""""""""""""""""""""""

--- a/src/user-guide/writing-suites/configuration.rst
+++ b/src/user-guide/writing-suites/configuration.rst
@@ -207,7 +207,7 @@ against a specification that defines all legal entries, values and options.
 It also performs some integrity checks designed to catch certain configuration
 issues and impossible scheduling constraints.
 
-These checks are also performed by ``cylc run`` before starting a workflow.
+These checks are also performed by ``cylc play`` before starting a workflow.
 
 All legal entries are documented in :cylc:conf:`flow.cylc`.
 

--- a/src/user-guide/writing-suites/external-triggers.rst
+++ b/src/user-guide/writing-suites/external-triggers.rst
@@ -355,7 +355,7 @@ Here's an example echo trigger suite:
            script = exit 1
 
 To see the result, run this suite in debug mode and take a look at the
-suite log (or run ``cylc run --debug --no-detach <suite>`` and watch
+suite log (or run ``cylc play --debug --no-detach <suite>`` and watch
 your terminal).
 
 

--- a/src/user-guide/writing-suites/jinja2.rst
+++ b/src/user-guide/writing-suites/jinja2.rst
@@ -248,7 +248,7 @@ This can be done on a case-by-case basis using the ``-s`` option e.g:
 .. code-block:: console
 
    $ # set the Jinja2 variable "answer" to 42
-   $ cylc run <flow> -s answer=42
+   $ cylc play <flow> -s answer=42
 
 Or for multiple options using a Cylc "set file" with ``--set-file``
 e.g:
@@ -263,7 +263,7 @@ e.g:
    __SET_FILE__
 
    $ # run using the options in the set file
-   $ cylc run <flow> --set-file my-set-file
+   $ cylc play <flow> --set-file my-set-file
 
 Values must be Python literals e.g:
 
@@ -289,7 +289,7 @@ Values must be Python literals e.g:
 
       $ # wrap the key=value pair in single quotes stop the shell from
       $ # stripping the inner quotes around the string:
-      $ cylc run <flow> -s 'my_string="a b c"'
+      $ cylc play <flow> -s 'my_string="a b c"'
 
 Here's an example:
 
@@ -341,8 +341,8 @@ will show the suite with the Jinja2 variables as set.
 .. note::
 
    Suites started with template variables set on the command
-   line will *restart* with the same settings. However, you can set
-   them again on the ``cylc restart`` command line if they need to
+   line will :term:`restart` with the same settings. However, you can set
+   them again on the ``cylc play`` command line if they need to
    be overridden.
 
 


### PR DESCRIPTION
Update docs after https://github.com/cylc/cylc-flow/pull/4040 and https://github.com/cylc/cylc-flow/pull/4076

Question: the existing docs barely mention hold/release - should I add entries in the glossary for them? Update: yes, closes #53