### PR TITLE
Fix build failure and move apt install step to its own action

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,29 @@
+name: Install dependencies
+description: apt-get dependencies plus pygraphviz
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "[command]sudo apt-get update"
+        sudo apt-get update
+
+    - shell: bash
+      run: |
+        echo "[command]sudo apt-get install -y ..."
+        sudo apt-get install -y \
+          librsvg2-bin \
+          ghostscript \
+          graphviz \
+          pkg-config \
+          libgraphviz-dev \
+          gsfonts \
+          libfreetype6-dev \
+          libfontconfig1-dev
+      # https://github.com/ImageMagick/ImageMagick/issues/374#issuecomment-279252866
+
+    - shell: bash
+      run: |
+        echo "[command]pip install pygraphviz"
+        pip install pygraphviz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,16 +58,11 @@ jobs:
           ref: ${{ github.event.inputs.cylc-flow-tag }}
           path: docs
 
-      - name: install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz pkg-config libgraphviz-dev
-          pip install pygraphviz
+      - name: install dependencies
+        uses: cylc/cylc-doc/.github/actions/install-dependencies@master
 
       - name: install cylc-doc
-        run: |
-          sudo apt-get install -y librsvg2-bin ghostscript
-          pip install "${{ github.workspace }}/docs[all]"
+        run: pip install "${{ github.workspace }}/docs[all]"
 
       - name: install libs to document
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,16 +42,11 @@ jobs:
           ref: master
           path: docs
 
-      - name: install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz pkg-config libgraphviz-dev
-          pip install pygraphviz
+      - name: install dependencies
+        uses: ./docs/.github/actions/install-dependencies
 
       - name: install cylc-doc
-        run: |
-          sudo apt-get install -y librsvg2-bin ghostscript
-          pip install "${{ github.workspace }}/docs[all]"
+        run: pip install "${{ github.workspace }}/docs[all]"
 
       - name: install libs to document
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,29 +30,14 @@ jobs:
         with:
             node-version: '10.x'
 
-      - name: install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            librsvg2-bin \
-            ghostscript \
-            graphviz \
-            pkg-config \
-            libgraphviz-dev
-          pip install pygraphviz
-
       - name: checkout cylc-doc
         uses: actions/checkout@v2
+
+      - name: install dependencies
+        uses: ./.github/actions/install-dependencies
+
       - name: install cylc-doc
-        run: |
-          # https://github.com/ImageMagick/ImageMagick/issues/374#issuecomment-279252866
-          sudo apt-get install -y \
-            librsvg2-bin \
-            ghostscript \
-            gsfonts \
-            libfreetype6-dev \
-            libfontconfig1-dev
-          pip install .[all]
+        run: pip install .[all]
 
       - name: install libs to document
         env:


### PR DESCRIPTION
Fix ``convert-im6.q16: unable to read font `helvetica'`` error on nightly & deploy workflows