### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,7 +77,9 @@ jobs:
         uses: cylc/release-actions/configure-git@v1
 
       - name: remove previous nightly build
+        id: remove-prev-build
         working-directory: gh-pages
+        continue-on-error: true
         run: |
           echo "::group::History before rebase: (you can still fetch these commits for recovery)"
           git log --oneline --graph --no-abbrev-commit gh-pages
@@ -85,17 +87,20 @@ jobs:
           echo "[command]git rebase -i --root"
           EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/drop \1/"' \
             git rebase -i --root
-          # if versions have been added/removed since the last build we
-          # will get conflicts on the versions.json file so we rebuild it
-          # now just in case
-          echo "[command]git diff --diff-filter=U"
+
+      # if versions have been added/removed since the last build, we will
+      # get conflicts on the versions.json file, so need to rebuild it
+      - name: fix rebase conflict
+        if: steps.remove-prev-build.outcome == 'failure'
+        working-directory: gh-pages
+        run: |
           git diff --diff-filter=U
-          echo "[command]../docs/bin/version write > versions.json"
-          ../docs/bin/version write > versions.json
+          echo "[command]../docs/bin/version . write > versions.json"
+          ../docs/bin/version . write > versions.json
           echo "[command]git add versions.json"
           git add versions.json
-          echo "[command]git rebase --continue || true"
-          git rebase --continue || true  # true incase there wasn't a conflict
+          echo "[command]git rebase --continue"
+          EDITOR=: git rebase --continue
 
       - name: build docs
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,18 +77,24 @@ jobs:
         uses: cylc/release-actions/configure-git@v1
 
       - name: remove previous nightly build
+        working-directory: gh-pages
         run: |
-          cd gh-pages
           echo "::group::History before rebase: (you can still fetch these commits for recovery)"
           git log --oneline --graph --no-abbrev-commit gh-pages
           echo "::endgroup::"
+          echo "[command]git rebase -i --root"
           EDITOR='sed -i "s/pick \([0-9a-z]* -nightly build-\)/drop \1/"' \
             git rebase -i --root
           # if versions have been added/removed since the last build we
           # will get conflicts on the versions.json file so we rebuild it
           # now just in case
+          echo "[command]git diff --diff-filter=U"
+          git diff --diff-filter=U
+          echo "[command]../docs/bin/version write > versions.json"
           ../docs/bin/version write > versions.json
+          echo "[command]git add versions.json"
           git add versions.json
+          echo "[command]git rebase --continue || true"
           git rebase --continue || true  # true incase there wasn't a conflict
 
       - name: build docs


### PR DESCRIPTION
The nightly build was failing on the step where it removes the previous nightly build.

See this fix in action: https://github.com/cylc/cylc-doc/runs/2217317677?check_suite_focus=true#step:11:1