### PR TITLE
Autodocument post-install plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ src/appendices/command-ref.rst
 
 # auto-generated documentation
 src/plugins/main-loop/built-in
-src/plugins/post-install/built-in
+src/plugins/install/built-in
 src/user-guide/task-implementation/job-runner-handlers

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ src/appendices/command-ref.rst
 
 # auto-generated documentation
 src/plugins/main-loop/built-in
+src/plugins/post-install/built-in
 src/user-guide/task-implementation/job-runner-handlers

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	# remove auto-generated content
 	rm -rf src/plugins/main-loop/built-in
-	rm -rf src/plugins/post-install/built-in
+	rm -rf src/plugins/install/built-in
 	rm -rf src/user-guide/task-implementation/job-runner-handlers
 
 cleanall:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ clean:
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	# remove auto-generated content
 	rm -rf src/plugins/main-loop/built-in
+	rm -rf src/plugins/post-install/built-in
 	rm -rf src/user-guide/task-implementation/job-runner-handlers
 
 cleanall:

--- a/src/_templates/docstring_only.rst
+++ b/src/_templates/docstring_only.rst
@@ -1,0 +1,3 @@
+{{ fullname | escape | underline }}
+
+.. automodule:: {{ fullname }}

--- a/src/plugins/index.rst
+++ b/src/plugins/index.rst
@@ -10,6 +10,7 @@ The following are "core" plugins maintained by the Cylc team:
 
    cylc-rose
    main-loop/index
+   post-install/index
 
 .. warning::
 

--- a/src/plugins/index.rst
+++ b/src/plugins/index.rst
@@ -10,7 +10,7 @@ The following are "core" plugins maintained by the Cylc team:
 
    cylc-rose
    main-loop/index
-   post-install/index
+   install/index
 
 .. warning::
 

--- a/src/plugins/install/index.rst
+++ b/src/plugins/install/index.rst
@@ -1,0 +1,4 @@
+Pre-Configure And Post-Install Plugins
+======================================
+
+.. automodule:: cylc.flow.install_plugins

--- a/src/plugins/post-install/index.rst
+++ b/src/plugins/post-install/index.rst
@@ -1,4 +1,0 @@
-Post-Install Plugins
-====================
-
-.. automodule:: cylc.flow.post_install

--- a/src/plugins/post-install/index.rst
+++ b/src/plugins/post-install/index.rst
@@ -1,0 +1,4 @@
+Post-Install Plugins
+====================
+
+.. automodule:: cylc.flow.post_install


### PR DESCRIPTION
Document the new `log_vc_info` post-install plugin (https://github.com/cylc/cylc-flow/pull/4142)