### PR TITLE
Document valid task names

### DIFF
--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -26,7 +26,7 @@ see :ref:`FamilyTriggers`.
 Namespace Names
 ---------------
 
-Namespace names may contain letters, digits, underscores, and hyphens.
+.. autoclass:: cylc.flow.unicode_rules.TaskNameValidator
 
 .. note::
 


### PR DESCRIPTION
> **Built on:** #238

Correct documentation on valid task names patterns by documenting from the source code.

<img width="447" alt="Screenshot 2021-04-27 at 16 53 21" src="https://user-images.githubusercontent.com/16705946/116272778-17f8e100-a779-11eb-834e-12c059fdb97c.png">