### PR TITLE
Fix overflowing diagrams

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:
       - name: configure python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 5
     steps:
       - name: configure python
@@ -39,7 +39,6 @@ jobs:
       - name: checkout cylc-doc
         uses: actions/checkout@v2
         with:
-          ref: master
           path: docs
 
       - name: install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:
       - name: configure python

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   undeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:
       - name: configure python


### PR DESCRIPTION
Closes #209 

Use `ubuntu-18.04` in GitHub Actions instead of latest so that the graphviz version we get isn't buggy. See https://github.com/cylc/cylc-doc/issues/209#issuecomment-853248945

I tested this using the nightly workflow and it worked (however, because the workflow ran as scheduled overnight using the master branch (with `ubuntu-latest`), it won't show up).