### PR TITLE
Glossary.event handlers

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1168,10 +1168,21 @@ Glossary
 
    event handlers
    handlers
-      Carry out an action when the Cylc scheduler detects that an arbitrary
-      event has occurred. This allows Cylc to centralize automated handling of
-      critical events. Cylc can do may things when it detects an event.
-      Use-cases include:
 
-      - Send an email message
-      - Run a Cylc command
+      :ref:`Event Handling documentation <EventHandling>`
+
+      An action you want the Cylc scheduler to run when it detects that an
+      event has occurred:
+
+      - For the :term:`scheduler`; for example startup, stall or shutdown.
+      - For a :term:`task`; for example when the :term:`task state` changes to
+        succeeded, failed or submit-failed.
+
+      This allows Cylc to centralize automated handling of critical events.
+      Cylc can do many things when it detects an event.
+
+      Possible use-cases include (but are not limited to):
+
+      - Send an email message.
+      - Run a Cylc command.
+      - Run _any_ user-specified script or command.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1165,3 +1165,13 @@ Glossary
 
          It is also possible to have multiple :term:`flows <flow>` running in the
          scheduler :term:`schduler` simultaneously.
+
+   event handlers
+   handlers
+      Carry out an action when the Cylc scheduler detects that an arbitrary
+      event has occurred. This allows Cylc to centralize automated handling of
+      critical events. Cylc can do may things when it detects an event.
+      Use-cases include:
+
+      - Send an email message
+      - Run a Cylc command

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1169,8 +1169,14 @@ Glossary
    event handlers
    handlers
 
-      :ref:`Event Handling documentation <EventHandling>`
+      .. seealso::
 
+         - :ref:`Event Handling documentation <EventHandling>`
+         - Task events configuration reference: 
+           :cylc:conf:`task events <[runtime][<namespace>][events]>`.
+         - Workflow events configuration reference: 
+           :cylc:conf:`workflow events <[scheduler][events]>`
+      
       An action you want the Cylc scheduler to run when it detects that an
       event has occurred:
 

--- a/src/user-guide/running-workflows.rst
+++ b/src/user-guide/running-workflows.rst
@@ -559,8 +559,8 @@ sequence by manually resetting it to the *failed* state.
 
 .. _EventHandling:
 
-Task Event Handling
--------------------
+Event Handling
+--------------
 
 * Task events (e.g. task succeeded/failed) are configured by
   :cylc:conf:`task events <[runtime][<namespace>][events]>`.

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -23,10 +23,19 @@ or for triggering other tasks off all members at once -
 see :ref:`FamilyTriggers`.
 
 
+.. _namespace-names:
+
 Namespace Names
 ---------------
 
 .. autoclass:: cylc.flow.unicode_rules.TaskNameValidator
+
+
+.. note::
+
+   - ``:`` would stop cylc adding paths using task name to ``$PATH``.
+   - ``.`` would be interpreted as a namespace delimeter.
+
 
 .. note::
 

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -30,13 +30,6 @@ Namespace Names
 
 .. autoclass:: cylc.flow.unicode_rules.TaskNameValidator
 
-
-.. note::
-
-   - ``:`` would stop cylc adding paths using task name to ``$PATH``.
-   - ``.`` would be interpreted as a namespace delimeter.
-
-
 .. note::
 
    *Task names need not be hardwired into task implementations*


### PR DESCRIPTION
Added a definition of "event handlers" to glossary. I'd have wanted it as a user.

Associated with https://github.com/cylc/cylc-flow/pull/4290