### PR TITLE
setup: bump cylc-sphinx-extensions to 1.3.1+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ VERSION = get_version(
 )
 
 INSTALL_REQUIRES = [
-    'cylc-sphinx-extensions>=1.3',
+    'cylc-sphinx-extensions>=1.3.1',
     'eralchemy==1.2.*',
     'hieroglyph>=2.1.0',
     'sphinx>=3.0.0',


### PR DESCRIPTION
Fixes bug documenting Cylc configurations caused by a nested section inside a meta section.