### PR TITLE
TZ defaults to UTC at Cylc 8, unless compat_mode

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -16,7 +16,7 @@ Terminology
    - And the Cylc config filename is now ``flow.cylc``, not ``suite.rc``
 
 
-.. _BackCompat:
+.. _Cylc_7_compat_mode:
 
 Backward Compatibility
 ----------------------
@@ -29,9 +29,12 @@ Workflows defined in a ``suite.rc`` file will be run in Cylc 7 compatibility
 mode. Changing the name of the definition file to ``flow.cylc`` will disable
 the compatibility mode.
 
-.. warning::
+.. warning:: Compatibility Mode Effects
 
-.. TODO: mention optional outputs and cycle point time zone default
+   - :cylc:conf:`[scheduler]cycle point time zone` defaults to local time in
+     compatibility mode.
+
+   .. TODO: mention optional outputs
 
 .. warning::
 

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -23,18 +23,20 @@ Backward Compatibility
 
 To make the transition easier, Cylc 8 can run Cylc 7 workflows out of the box.
 If Cylc detects that a workflow is using the deprecated ``suite.rc`` filename,
-it will turn on a backwards compatibility mode, which:
+it will turn on a backwards compatibility mode.
 
-Workflows defined in a ``suite.rc`` file will be run in Cylc 7 compatibility
-mode. Changing the name of the definition file to ``flow.cylc`` will disable
-the compatibility mode.
+Compatibility Mode Effects
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning:: Compatibility Mode Effects
+- Allows :term:`implicit tasks <implicit task>` without having to set
+  :cylc:conf:`flow.cylc[scheduler]allow implicit tasks` (unless a
+  ``rose-suite.conf`` file is present in the :term:`run directory`, to maintain
+  compatibility with Rose 2019).
+- Sets the default :cylc:conf:`[scheduler]cycle point time zone` to local time
+  of the workflow's initial start (including any daylight saving changes),
+  rather than UTC.
 
-   - :cylc:conf:`[scheduler]cycle point time zone` defaults to local time in
-     compatibility mode.
-
-   .. TODO: mention optional outputs
+.. TODO: mention optional outputs
 
 .. warning::
 

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -25,10 +25,11 @@ To make the transition easier, Cylc 8 can run Cylc 7 workflows out of the box.
 If Cylc detects that a workflow is using the deprecated ``suite.rc`` filename,
 it will turn on a backwards compatibility mode, which:
 
-- Allows :term:`implicit tasks <implicit task>` without having to set
-  :cylc:conf:`flow.cylc[scheduler]allow implicit tasks` (unless a
-  ``rose-suite.conf`` file is present in the :term:`run directory`, to maintain
-  compatibility with Rose 2019).
+Workflows defined in a ``suite.rc`` file will be run in Cylc 7 compatibility
+mode. Changing the name of the definition file to ``flow.cylc`` will disable
+the compatibility mode.
+
+.. warning::
 
 .. TODO: mention optional outputs and cycle point time zone default
 
@@ -331,6 +332,14 @@ The following dependencies are not installed by Conda or pip:
 - ``bash``
 - GNU ``coreutils``
 - ``mail`` (for automated email functionality)
+
+Time Zones
+----------
+
+:cylc:conf:`[scheduler]cycle point time zone` now defaults to UTC, unless you
+are working in :ref:`Cylc 7 compatibility mode <Cylc_7_compat_mode>`.
+
+.. seealso:: :ref:`Scheduling syntax rules<writing_flows.scheduling.syntax_rules>`
 
 What's Still Missing From Cylc 8?
 ---------------------------------

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -23,10 +23,7 @@ Backward Compatibility
 
 To make the transition easier, Cylc 8 can run Cylc 7 workflows out of the box.
 If Cylc detects that a workflow is using the deprecated ``suite.rc`` filename,
-it will turn on a backwards compatibility mode.
-
-Compatibility Mode Effects
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+it will turn on a backwards compatibility mode, which:
 
 - Allows :term:`implicit tasks <implicit task>` without having to set
   :cylc:conf:`flow.cylc[scheduler]allow implicit tasks` (unless a

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -323,7 +323,7 @@ The time is assumed to be in UTC unless you set
 
    At Cylc 7 the time zone was assumed to be local time unless
    :cylc:conf:`[scheduler]cycle point time zone` or :cylc:conf:`[scheduler]UTC mode`
-   was set. If you run your workflow in :ref:`Cylc 7 compatibility mode <Cylc_7_compat_mode>`
+   was set. If your workflow is running in :ref:`Cylc 7 compatibility mode <Cylc_7_compat_mode>`
    this remains the case.
 
 The calendar is assumed to be the proleptic Gregorian calendar unless

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -305,6 +305,8 @@ number of repetitions.
 Graph section heading can also be used with
 :ref:`integer cycling <IntegerCycling>`.
 
+.. _writing_flows.scheduling.syntax_rules:
+
 Syntax Rules
 ^^^^^^^^^^^^
 
@@ -312,8 +314,18 @@ Syntax Rules
 starting :term:`datetime <ISO8601 datetime>`, an interval, and an optional
 limit.
 
-The time is assumed to be in the local time zone unless you set
-:cylc:conf:`[scheduler]cycle point time zone` or :cylc:conf:`[scheduler]UTC mode`.
+The time is assumed to be in UTC unless you set
+:cylc:conf:`[scheduler]cycle point time zone`.
+
+.. attention::
+
+   .. versionchanged:: 8.0.0
+
+   At Cylc 7 the time zone was assumed to be local time unless
+   :cylc:conf:`[scheduler]cycle point time zone` or :cylc:conf:`[scheduler]UTC mode`
+   was set. If you run your workflow in :ref:`Cylc 7 compatibility mode <Cylc_7_compat_mode>`
+   this remains the case.
+
 The calendar is assumed to be the proleptic Gregorian calendar unless
 you set :cylc:conf:`[scheduling]cycling mode`.
 


### PR DESCRIPTION
Doc changes for https://github.com/cylc/cylc-flow/pull/4457

[Additional] Noted the existence of compatibility mode in the 7-to-8 summary. 

tests will fail pending #304 