### PR TITLE
change default text role to :cylc:conf:

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -11,8 +11,8 @@ To make the transition easier, Cylc 8 can run Cylc 7 workflows out of the box.
 
 .. warning::
 
-   But please take action on any deprecation warnings emitted by `cylc
-   validate`.
+   But please take action on any deprecation warnings emitted by
+   ``cylc validate``.
 
 
 Terminology
@@ -293,7 +293,7 @@ Cylc 8 can be installed from **Conda Forge**, into a conda environment:
    (cylc8) $ cylc --version
    cylc-8.0b0
 
-Or from **PyPI**, into a Python 3 virtual environment, by `pip`-installing the
+Or from **PyPI**, into a Python 3 virtual environment, by ``pip``-installing the
 UI Server component, which pulls in cylc-flow (Scheduler and CLI) as a
 dependency, and includes a built copy of cylc-ui (Javascript UI):
 
@@ -307,14 +307,14 @@ dependency, and includes a built copy of cylc-ui (Javascript UI):
 
 The following dependencies are installed by Conda but not by pip:
 
-- `configurable-http-proxy` (used by the Hub)
+- ``configurable-http-proxy`` (used by the Hub)
 - Python
 
 The following dependencies are not installed by Conda or pip:
 
-- `bash`
-- GNU `coreutils`
-- `mail` (for automated email functionality)
+- ``bash``
+- GNU ``coreutils``
+- ``mail`` (for automated email functionality)
 
 What's Still Missing From Cylc 8?
 ---------------------------------

--- a/src/conf.py
+++ b/src/conf.py
@@ -47,6 +47,7 @@ extensions = [
 ]
 
 rst_epilog = open('hyperlinks.rst.include', 'r').read()
+default_role = 'cylc:conf'
 
 # Select best available SVG image converter.
 for svg_converter, extension in [

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -975,7 +975,7 @@ Glossary
       * :ref:`Family Trigger Tutorial <tutorial-cylc-family-triggers>`
 
    message trigger
-      A `message trigger` can be used to trigger a dependent
+      A message trigger can be used to trigger a dependent
       :term:`task <task>` before the upstream task has completed.
 
       We can use :term:`custom task outputs <custom task output>` as triggers.
@@ -989,7 +989,7 @@ Glossary
       * :term:`custom task output`
 
    custom task output
-      A `custom task output` is a user-defined message sent from the
+      A custom task output is a user-defined message sent from the
       :term:`job` to the workflow server.
       These can be used as :term:`message triggers <message trigger>`.
 

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -334,7 +334,7 @@ triggers another task bar and when fully completed triggers another task, baz.
       It is a good idea to check that our :cylc:conf:`flow.cylc` file does not have any
       configuration issues.
 
-      Run `cylc validate` to check for any errors:
+      Run ``cylc validate`` to check for any errors:
 
       .. code-block:: bash
 

--- a/src/tutorial/runtime/configuration-consolidation/families.rst
+++ b/src/tutorial/runtime/configuration-consolidation/families.rst
@@ -158,7 +158,7 @@ The ``root`` Family
 
 .. ifnotslides::
 
-   There is a special family called `root` (in lowercase) which is used only
+   There is a special family called ``root`` (in lowercase) which is used only
    in the runtime to provide configuration which will be inherited by all
    tasks.
 

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -280,7 +280,7 @@ Start, Stop, Restart
       This sets the :term:`final cycle point` six hours after the
       :term:`initial cycle point`.
 
-      Run `cylc validate` to check for any errors::
+      Run ``cylc validate`` to check for any errors::
 
          cylc validate .
 

--- a/src/user-guide/installing-workflows.rst
+++ b/src/user-guide/installing-workflows.rst
@@ -260,7 +260,7 @@ For example, using the command line option
 To skip making localhost symlinks
 """""""""""""""""""""""""""""""""
 
-Use `--symlink-dirs=""` with the `cylc install` command.
+Use ``--symlink-dirs=""`` with the ``cylc install`` command.
 
 
 

--- a/src/user-guide/task-implementation/job-submission.rst
+++ b/src/user-guide/task-implementation/job-submission.rst
@@ -113,8 +113,8 @@ re-triggered multiple times:
 
 How the stdout and stderr streams are directed into these files depends on the
 :term:`job runner`. The
-py:mod:`background <cylc.flow.job_runner_handlers.background>` method just uses
-appropriate output redirection on the command line, as shown above. The
+:py:mod:`background <cylc.flow.job_runner_handlers.background>` method just
+uses appropriate output redirection on the command line, as shown above. The
 :py:mod:`loadleveler <cylc.flow.job_runner_handlers.loadleveler>` method writes
 appropriate directives to the job script that is submitted to loadleveler.
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1582,7 +1582,7 @@ can be replaced by a single sequential declaration,
 Future Triggers
 ^^^^^^^^^^^^^^^
 
-Cylc also supports term:`inter-cycle triggering <inter-cycle trigger>` off
+Cylc also supports :term:`inter-cycle triggering <inter-cycle trigger>` off
 tasks "in the future" (with respect to cycle point - which has no bearing on
 wall-clock job submission time unless the task has a clock trigger):
 


### PR DESCRIPTION
* The "default text role" applies to text in single backquotes.
* This often applies to corrupted reST syntax or literals which were
  mistakenly formatted as markdown.
* By changing the default text role to something that performs some
  form of validation we can catch these mistakes automatically.
* This changes the default text role to :cylc:conf: as this role is
  quite strict (e.g. the text must be a valid Cylc namespace) which is
  very hard to achieve accidentally.

> **Note:** I have chosen `:cylc:conf:`, however, other options are available.

> **Note:** Requires the fixes in https://github.com/cylc/cylc-flow/pull/4463 to build