### PR TITLE
Forbid flow.cylc and suite.rc

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -33,6 +33,12 @@ it will turn on a backwards compatibility mode, which:
   of the workflow's initial start (including any daylight saving changes),
   rather than UTC.
 
+.. note::
+
+   Attempting to ``cylc play`` a workflow with both ``flow.cylc`` and
+   ``suite.rc`` files in the same :term:`run directory` will result in an
+   error and will not trigger back compatibility mode. 
+
 .. TODO: mention optional outputs
 
 .. warning::
@@ -266,6 +272,11 @@ workflow files into the run directory at start-up
    $ cylc play democ8/run2
    # etc.
 
+.. note::
+
+   Cylc 8 forbids having both ``flow.cylc`` and ``suite.rc`` files in the same
+   :term:`run directory` or :term:`source directory`.
+
 Deleting workflows can be done using ``cylc clean`` - see
 :ref:`Removing-workflows`.
 
@@ -280,6 +291,7 @@ the intended restart.
 Cylc 8 has ``cylc play`` to *start*, *restart*, or *unpause* a workflow, so
 "restart" is now the safe default behaviour. For a new run from scratch,
 do a fresh ``cylc install`` and run it safely in the new run directory.
+
 
 Security
 --------

--- a/src/user-guide/installing-workflows.rst
+++ b/src/user-guide/installing-workflows.rst
@@ -383,6 +383,9 @@ If:
 - neither :cylc:conf:`flow.cylc` nor the deprecated suite.rc are found in
   the :term:`source directory`
 
+- Both :cylc:conf:`flow.cylc` and the deprecated suite.rc are found in
+  the :term:`source directory`. Only one should be present.
+
 - the run-name is specified as ``_cylc-install``
 
 - the workflow name is an absolute path or invalid


### PR DESCRIPTION
Small PR, informs users you can not have both a `suite.rc` and `flow.cylc` file in run directory or source directory.

Documents https://github.com/cylc/cylc-flow/pull/4497.

