### PR TITLE
GH Actions: Fix a couple of issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,14 @@ on:
         required: true
       set_stable:
         description: 'Stable build. Make this the default documented version.'
-        required: false
+        type: boolean
         default: true
+        required: false
       set_latest:
         description: 'Latest build (but not the default version). If the build is both the Latest and the Stable/default, use `set_stable` as well.'
-        required: false
+        type: boolean
         default: true
+        required: false
 
 jobs:
   deploy:
@@ -84,7 +86,7 @@ jobs:
           path: gh-pages
 
       - name: sync static files
-        if: ${{ github.event.inputs.set_stable }}
+        if: ${{ github.event.inputs.set_stable == 'true' }}
         run: |
           DOCS="${{ github.workspace }}/docs" \
           PAGE="${{ github.workspace }}/gh-pages"  \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-18.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: configure python
         uses: actions/setup-python@v2


### PR DESCRIPTION
- Nightly build timing out
- Use new boolean type for workflow input - https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/
- `if` condition in deploy workflow doesn't work as expected - https://github.com/actions/runner/issues/1483