### PR TITLE
Pin setuptools to >= 50.

### DIFF
--- a/.github/workflows/create-conda-envs.yml
+++ b/.github/workflows/create-conda-envs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install
         run: |
           # pick up deps for version processing
-          pip install 'setuptools>=49'
+          pip install 'setuptools>=50'
 
       - name: checkout cylc-flow init file
         run: |

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     'cylc-sphinx-extensions>=1.3.3',
     'eralchemy==1.2.*',
     'hieroglyph>=2.1.0',
-    'setuptools>=49',
+    'setuptools>=50',
     'sphinx>=3.0.0',
     'sphinx_rtd_theme>=0.5.0',
     'sphinxcontrib-svg2pdfconverter',


### PR DESCRIPTION
Discussed offline, `setuptools` version 49 breaks doc build due to changes in #342; but version 50 works.  