### PR TITLE
Tweak release messaging.

### DIFF
--- a/src/hyperlinks.rst.include
+++ b/src/hyperlinks.rst.include
@@ -6,7 +6,7 @@
 .. _Cylc User Guide: https://cylc.github.io/cylc-doc/latest/html/index.html
 .. _Cylc Workflow Design Guide: https://cylc.github.io/cylc-doc/latest/html/workflow-design-guide/index.html
 .. _Cylc: https://cylc.github.io/
-.. _Cylc 8 Discourse Support Group: https://cylc.discourse.group/c/cylc/7-to-8/13
+.. _Cylc Discourse Forum (7-to-8 topic): https://cylc.discourse.group/c/cylc/7-to-8/13
 .. _DataPoint: https://www.metoffice.gov.uk/services/data/datapoint
 .. _Discourse: https://cylc.discourse.group/
 .. _EmPy: http://www.alcyone.com/software/empy/

--- a/src/index.rst
+++ b/src/index.rst
@@ -5,22 +5,16 @@ Cylc ("*silk*") is a workflow engine for cycling systems - it orchestrates
 distributed workflows of interdependent cycling tasks that may continue to run
 indefinitely.
 
+.. The following note is also included in the installation section.
+
+.. include:: release-note.rst
+
 .. image:: https://img.shields.io/discourse/users?label=Join%20the%20community%20on%20Discourse&logo=discourse&server=https%3A%2F%2Fcylc.discourse.group&style=socia0l
    :align: center
    :width: 50%
    :target: https://cylc.discourse.group
 
-.. Note the following warning is also given at the top of the installation section.
-
-.. warning::
-
-   Cylc 8.0b3 is the final *beta release* of Cylc 8, a major upgrade from Cylc 7.
-
-   All Cylc 8 system components are in place but not yet heavily tested by users. 
-   Cylc 7 is still available if needed.
-
-   This documentation has been revised for Cylc 8, but some new features are
-   yet to be fully described.
+|
 
 .. toctree::
    :maxdepth: 2

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -3,12 +3,9 @@
 Installation
 ============
 
-.. note::
+.. The following note is also included in the main index.
 
-   Cylc |release| is a pre release not recommended for production use.
-
-   Please report any issues to the `Cylc 8 Discourse Support Group`_.
-
+.. include:: release-note.rst
 
 Quick Installation
 ------------------

--- a/src/reference/environments/conda.rst
+++ b/src/reference/environments/conda.rst
@@ -12,14 +12,13 @@ all components:
    :language: YAML
    :substitutions:
 
-For finer control over installation the following sections outline alternative
-installations.
+The following sections outline alternatives for finer control over installation.
 
 
 Cylc Flow
 ---------
 
-The most simple Cylc installation consists only of `Cylc Flow`_:
+The simplest Cylc installation consists only of `Cylc Flow`_:
 
 .. literalsubinclude:: envs/cylc-flow.yml
    :language: YAML

--- a/src/release-note.rst
+++ b/src/release-note.rst
@@ -1,0 +1,8 @@
+.. note::
+
+   Cylc |release| is the final *beta* pre-release of Cylc 8. It is largely
+   complete and can be used to manage real workflows, but it has not yet been
+   heavily tested by users. Python 2 based Cylc 7 is stable and still available
+   if needed for production systems.
+
+   Please report migration issues to the `Cylc Discourse Forum (7-to-8 topic)`_.


### PR DESCRIPTION
I had a pending review of #342 that I forgot to finish off before it got trumped by other reviewers.

My main issue was:
> It's important to convey that although 8.0b3 is a still a "pre-release", it is now close enough to complete to be fully useable, with the disclaimer that it has not yet been heavily tested by users (although it has by us). Because, as recently reported on the forum, some sites are already facing new platforms without Python 2 available and our "not recommended for production use" messaging is putting them off Cylc 8.

I've attempted to strike a compromise that let's users decide if they want to take the risk, and that "Cylc 7 is stable and still available if needed".