### PR TITLE
deploy wf tweak

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,12 +89,6 @@ jobs:
           git clone --depth 1 --branch "${meto_rose}" https://github.com/metomi/rose ../rose
           pip install -e ../rose[all]
 
-      - name: create conda envs
-        uses: ./.github/actions/create-conda-envs
-        continue-on-error: ${{ github.event.inputs.skip_conda_environment_check }}
-        with:
-          python_version: '3.7'
-
       - name: checkout gh-pages
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The "create conda envs" action in the `deploy` workflow isn't working. 

It fails because of a path problem, and `continue-on-error` isn't working either (`unexpected value: 'true'`)

I couldn't figure this out quickly so I deleted the whole block, and used this branch to deploy the 8.0b3 docs.

Probably want to fix it rather than merge this.