### PR TITLE
Tidy up file format documentation.

### DIFF
--- a/src/reference/config/file-format.rst
+++ b/src/reference/config/file-format.rst
@@ -6,6 +6,7 @@ The .cylc File Format
 Cylc global and workflow configuration files are written in a nested
 `INI`_-based format.
 
+.. _syntax:
 
 Syntax
 ------

--- a/src/reference/config/file-format.rst
+++ b/src/reference/config/file-format.rst
@@ -1,0 +1,179 @@
+.. _file-format:
+
+The .cylc File Format
+=====================
+
+Cylc global and workflow configuration files are written in a nested
+`INI`_-based format.
+
+
+Syntax
+------
+
+Comments
+   Comments follow a ``#`` character.
+
+Settings
+   Configuration items (settings) are written as ``key = value`` pairs, and can
+   be contained within sections. Setting names (the keys) may contain spaces.
+
+String Values
+   Quoting single-line string values is optional:
+
+   .. code-block:: cylc
+
+      [animals]
+         cat = dusty
+         dog = "fido"  # or single quotes: 'fido'
+
+   Multiline string values must be triple-quoted:
+
+   .. code-block:: cylc
+
+      [song]
+         lyrics = """  # (or triple single-quotes: '''value''')
+            No stop signs
+            Speed limit
+            Nobody's gonna slow me down
+         """
+
+List Values
+   List values are comma-separated:
+
+   .. code-block:: cylc
+
+      animals = dusty, fido, cujo
+
+
+Boolean Values
+   Booleans are capitalized:
+
+   .. code-block:: cylc
+
+      ice cream is good = True  # or False
+
+
+Sections and Sub-sections
+   Settings have a level-dependendent number of square brackets:
+
+   .. code-block:: cylc
+
+      [section]
+      [[sub-section]]
+      [[[sub-sub-section]]]
+
+
+Indentation
+   It is advisable to indent sections and subsections, for clarity. However,
+   Cylc ignores indentation, so this:
+
+   .. code-block:: cylc
+
+      [section]
+         a = A
+         [[sub-section]]
+            b = B
+         b = C  # WARNING: this is still in sub-section!
+
+   is equivalent to this:
+
+   .. code-block:: cylc
+
+      [section]
+         a = A
+         [[sub-section]]
+            b = C
+
+
+Duplicate Sections and Items
+   Duplicate sections get merged into one. Duplicate settings overwrite
+   previously defined values. So this:
+
+   .. code-block:: cylc
+
+      [animals]
+        cat = fluffy
+      [animals]
+        dog = fido
+        cat = dusty
+ 
+   is equivalent to this:
+
+   .. code-block:: cylc
+
+      [animals]
+        cat = dusty
+        dog = fido
+
+
+   The only exception to this rule is :term:`graph strings <graph string>`,
+   which get merged. So these graph strings:
+
+   .. code-block:: cylc-graph
+
+      R1 = "foo => bar"
+      R1 = "foo => baz"
+
+   merge to this:
+
+   .. code-block:: cylc-graph
+
+      R1 = "foo => bar & baz"
+
+
+Continuation lines
+   If necessary, you can continue on the next line after a backslash character:
+
+   .. code-block:: cylc
+
+      verse = "the quick \
+               brown fox"
+
+   However, backslash line continuation is fragile (trailing invisible
+   whitespace breaks it). Long :term:`graph strings <graph string>` strings
+   should be split on graph symbols instead:
+
+   .. code-block:: cylc-graph
+
+      R1 = """
+           (foo & bar ) |
+               baz =>
+                   qux
+      """
+      # Equivalent to:
+      R1 = """
+           (foo & bar ) | baz => qux
+      """
+
+Include-files
+   ``flow.cylc`` fragments can be included verbatim with the ``%include``
+   directive. Include-files can be included multiple times, and even nested.
+   Include-file paths should relative to the ``flow.cylc`` location:
+
+   .. code-block::
+
+      %include "inc/site-a.cylc"
+
+   :ref:`Jinja2's <Jinja>` template inclusion mechanism can be used with Cylc
+   too.
+
+
+Shorthand
+---------
+
+Throughout the documentation we refer to configuration settings in the
+following way:
+
+``[section]``
+   An entire section.
+``[section]setting``
+   A setting within a section.
+``[section]setting=value``
+   The value of a setting within a section.
+``[section][sub-section]another-setting``
+   A setting within a sub-section.
+
+.. warning::
+   We only use one set of square brackets at each level when writing nested
+   sections on one line like this. But in the file, each sub-section
+   gets additional square brackets as shown above.

--- a/src/reference/config/global.rst
+++ b/src/reference/config/global.rst
@@ -1,5 +1,6 @@
 Global Configuration
 ====================
 
+Cylc global configurations use the :ref:`.cylc file format <file-format>`.
 
 .. auto-cylc-conf:: cylc.flow.cfgspec.globalcfg.SPEC

--- a/src/reference/config/index.rst
+++ b/src/reference/config/index.rst
@@ -4,6 +4,7 @@ Configuration
 .. toctree::
    :maxdepth: 2
 
+   file-format
    workflow
    global
    types

--- a/src/reference/config/workflow.rst
+++ b/src/reference/config/workflow.rst
@@ -1,4 +1,8 @@
+.. _workflow-configuration:
+
 Workflow Configuration
 ======================
+
+Cylc workflow configurations use the :ref:`.cylc file format <file-format>`.
 
 .. auto-cylc-conf:: cylc.flow.cfgspec.workflow.SPEC

--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -15,6 +15,8 @@ Graphing
 The :cylc:conf:`flow.cylc` File Format
 --------------------------------------
 
+.. TODO consider refering to the reference section file-format doc here.
+
 .. ifnotslides::
 
    A :term:`Cylc workflow` is defined by a :cylc:conf:`flow.cylc` configuration

--- a/src/user-guide/writing-workflows/configuration.rst
+++ b/src/user-guide/writing-workflows/configuration.rst
@@ -3,15 +3,26 @@
 Workflow Configuration
 ======================
 
-Cylc workflows are defined in structured, validated, :cylc:conf:`flow.cylc`
-files that specify the properties of, and the relationships between, the
-various tasks to be managed by the Cylc scheduler.
+.. _FlowConfigFile:
 
-Here we will look at:
+The ``flow.cylc`` File
+----------------------
 
-- Folders which may accompany a workflow configuration.
-- The content of the :cylc:conf:`flow.cylc` file.
-- How to configure workflows.
+Cylc workflows are defined in :cylc:conf:`flow.cylc` files that specify the
+tasks to be managed by the Cylc scheduler, the dependencies between them,
+and the schedules to run time on.
+
+General file syntax is described in the :ref:`File Format Reference
+<file-format>`.
+
+Legal configuration settings are documented in :ref:`workflow-configuration`.
+
+.. _template processors: https://en.wikipedia.org/wiki/Template_processor
+
+Cylc also supports two `template processors`_ for use in the ``flow.cylc`` file:
+
+* `Jinja2`_
+* `EmPy`_
 
 
 .. _WorkflowDefinitionDirectories:
@@ -43,75 +54,6 @@ A Cylc :term:`source directory` contains:
 Other files and folders may be placed in the :term:`source directory` too:
 documentation, configuration files, etc. When the workflow is :ref:`installed
 <Installing-workflows>` these will be copied over to the :term:`run directory`.
-
-.. _FlowConfigFile:
-
-flow.cylc File Overview
------------------------
-
-The :cylc:conf:`flow.cylc` file is written in a nested `INI`_-based format.
-
-.. _template processors: https://en.wikipedia.org/wiki/Template_processor
-
-Cylc also supports two `template processors`_ for use in the ``flow.cylc`` file:
-
-* `Jinja2`_
-* `EmPy`_
-
-
-.. _Syntax:
-
-Syntax
-^^^^^^
-
-:cylc:conf:`flow.cylc` syntax, in general terms:
-
-- **Settings** (config items) are of the form ``item = value``.
-- **[Section]** headings are enclosed in square brackets.
-
-  - **Sub-section [[nesting]]** is defined by repeated square brackets.
-  - Sections are **closed** implicitly by the next section heading.
-
-- **Comments** (line and trailing) follow a hash character: ``#``
-- **List values** are comma-separated.
-- **Single-line string values** can be single-, double-, or un-quoted.
-- **Multi-line string values** are triple-quoted (using
-  single or double quote characters).
-- **Boolean values** are capitalized: True, False.
-- **Leading and trailing whitespace** is ignored.
-- **Indentation** is optional but should be used for clarity.
-- **Continuation lines** follow a trailing backslash: ``\``
-- **Duplicate sections** add their items to those previously
-  defined under the same section.
-- **Duplicate items** override, except for ``graph`` strings, which are
-  additive.
-- **Include-files** ``%include inc/foo.cylc`` can be used as a verbatim
-  inlining mechanism.
-
-Workflows that embed templating code (see :ref:`User Guide Jinja2` and
-:ref:`User Guide EmPy`) must process to raw :cylc:conf:`flow.cylc` syntax.
-
-
-Include-Files
-^^^^^^^^^^^^^
-
-Cylc has native support for :cylc:conf:`flow.cylc` include-files, which may help to
-organize large workflows. Inclusion boundaries are completely arbitrary -
-you can think of include-files as chunks of the :cylc:conf:`flow.cylc` file simply
-cut-and-pasted into another file. Include-files may be included
-multiple times in the same file, and even nested. Include-file paths
-can be specified portably relative to the workflow configuration directory,
-e.g.:
-
-.. code-block:: cylc
-
-   # include the file ~/cylc-run/workflow/inc/foo.cylc:
-   %include inc/foo.cylc
-
-.. note::
-
-   Template processors may have their own include functionality
-   which can also be used.
 
 
 .. _SyntaxHighlighting:


### PR DESCRIPTION
Had a couple of new users confused about the file format. E.g., this was only documented in the tutorial:

>    We only use one set of square brackets at each level when writing nested sections on one line. But in the file, each nested sub-section gets a another set of square brackets as shown above.

So I added a new Reference section, and just referred out to that in the User Guide.
 
@wxtim may be some overlap with your tutorial rewrite (I just added a TODO comment to the tutorial docs here, since we haven't decided where that'll end up yet).