### PR TITLE
Create custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <base href="/cylc-doc/">
+
+  <title>Page not found</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link rel="icon" href="latest/html/_static/cylc-favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="latest/html/_static/cylc-favicon.ico" type="image/x-icon">
+
+  <link rel="stylesheet" href="etc/404.css">
+
+  <script src="etc/404.js"></script>
+</head>
+
+<body class="no-js">
+  <div id="container">
+
+    <div id="content">
+
+      <div class="wrapper">
+        <img id="logo404" src="latest/html/_static/cylc-logo-white.svg"/>
+
+        <section id="http404-notice">
+          <h1>Page not found</h1>
+          <p>
+            Page addresses may have changed between Cylc versions
+          </p>
+          <p>
+            You can either go back, or go to the homepage for Cylc <span class="version-num">stable</span> documentation
+          </p>
+          <div class="button-container">
+            <a id="back-button" onclick="history.go(-1);" class="button" style="cursor: pointer;">
+              Go back
+            </a>
+            <a id="home-button" href="stable/html/index.html" class="button">
+              Cylc <span class="version-num">stable</span> docs
+            </a>
+          </div>
+        </section>
+
+      </div>
+
+    </div>
+
+    <footer>
+      <div class="wrapper">
+        <small>&copy; NIWA &amp; British Crown (Met Office) &amp; Contributors</small>
+      </div>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/etc/404.css
+++ b/etc/404.css
@@ -1,0 +1,143 @@
+/* ------- Defaults ------- */
+
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol, ul {
+  list-style: none;
+}
+blockquote, q {
+  quotes: none;
+}
+blockquote:before, blockquote:after, q:before, q:after {
+  content: '';
+  content: none;
+}
+strong, b {
+  font-weight: 700;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+img {
+  -ms-flex-shrink: 0;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
+}
+
+
+/* ------- Main Styling ------- */
+
+html, body {
+    height: 100%;
+}
+body {
+    width: 100%;
+    background: #DDD;
+    color: #333;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+
+.wrapper {
+    max-width: 1000px;
+    margin: 0 auto;
+}
+#content {
+    padding: 40px 0;
+}
+#content .wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+#content section {
+    margin: 40px;
+    font-size: 18px;
+}
+#content section > * {
+    margin: 20px 0;
+}
+#content section h1 {
+    font-size: 28px;
+    font-weight: 600;
+}
+#content a:not(.button) {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid #000;
+}
+#content a:not(.button) {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid #000;
+}
+#content a:not(.button):hover {
+    color: #00b4fd;
+    border-color: #00b4fd;
+}
+#logo404 {
+    width: 400px;
+}
+
+.button-container {
+    display: flex;
+    justify-content: center;
+    padding-top: 10px;
+}
+.button-container > .button {
+    margin-right: 20px;
+}
+.button-container > .button:last-child {
+    margin-right: 0;
+}
+.button {
+    display: block;
+    text-decoration: none;
+    font-size: 16px;
+    padding: 12px 18px;
+    color: inherit;
+    border: 1px solid #555;
+    border-radius: 5px;
+}
+.button:hover {
+    background: #00b4fd;
+    color: #FFF;
+    border-color: #00b4fd;
+}
+
+.no-js #back-button {
+    display: none;
+}
+
+footer {
+    font-size: 14px;
+    text-align: center;
+    color: #555;
+}

--- a/etc/404.js
+++ b/etc/404.js
@@ -1,0 +1,52 @@
+/**
+ * Returns the version string from the URL pathname, if applicable.
+ * @param {string} base - The base of the pathname, usually '/cylc-doc/'
+ * @param {string} path - The pathname from the URL
+ * @returns {string|undefined} version
+ */
+ function getVersion(base, path) {
+    if (!path.startsWith(base)) {
+        return;
+    }
+    path = path.replace(base, '');
+    let pathArr = path.split('/');
+    if (pathArr.length < 2 || pathArr[1] !== 'html') {
+        return;
+    }
+    return pathArr[0];
+}
+
+
+/**
+ * Update the HTML with the Cylc version garnered from the URL.
+ * @param {string} version
+ */
+function setVersionInHTML(version) {
+    document.getElementById('home-button')
+        .setAttribute('href', `${version}/html/index.html`);
+    document.querySelectorAll('.version-num').forEach((e) => {
+        e.innerHTML = version;
+    });
+}
+
+
+window.onload = () => {
+    const body = document.querySelector('body');
+    body.classList.remove('no-js');
+
+    // Try and get version from URL
+    const base = document.querySelector('base').getAttribute('href');
+    let path = window.location.pathname;
+
+    const version = getVersion(base, path);
+    if (!version) return;
+
+    // Check against existing versions
+    fetch(`${base}versions.json`, {method: 'GET'})
+        .then((response) => response.json())
+        .then((versions) => {
+            if (version in versions) {
+                setVersionInHTML(version);
+            }
+        });
+};


### PR DESCRIPTION
Detects the version you tried to navigate to, offers a link to the docs homepage for that version. This is better than the current 404 page which offers no options.

To see a demo
- Go to https://metronnie.github.io/cylc-doc/8.0b3/html/7-to-8/index.html
- Try changing the version to 7.8.8 in the lower left sidebar

![image](https://user-images.githubusercontent.com/61982285/146027561-45239c0f-b766-4680-a04f-c8863c06d5c9.png)

Note if you try entering an invalid version in the URL, it will only offer the link to the stable docs homepage