### PR TITLE
Delete broken tutorial symlink

### DIFF
--- a/src/_static/tutorial
+++ b/src/_static/tutorial
@@ -1,1 +1,0 @@
-../../cylc/doc/etc/tutorial/


### PR DESCRIPTION
This broken symlink appears to be making `test-tutorial-workflow` CI fail at its new home on cylc-flow