### PR TITLE
Fix additional tutorials

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -208,11 +208,6 @@ Optional and Expected Task Outputs
    * :ref:`User Guide Expected Outputs`
    * :ref:`User Guide Optional Outputs`
 
-   Tutorials:
-
-   * :ref:`tutorial-cylc-family-triggers` - contains examples of tasks with
-     optional outputs.
-
    Major Changes:
 
    * :ref:`728.suicide_triggers`
@@ -336,9 +331,6 @@ Cylc Install
 .. seealso::
 
    * :ref:`Moving to Cylc Install<majorchangesinstall>`.
-   * :ref:`tutorials.furthertopics` have been re-written to use cylc install.
-   * :ref:`tutorial.furthertopics.queues` provides an example of using
-     named runs.
 
 
 Cylc install cleanly separates workflow source directory from run directory,

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -208,6 +208,11 @@ Optional and Expected Task Outputs
    * :ref:`User Guide Expected Outputs`
    * :ref:`User Guide Optional Outputs`
 
+   Tutorials:
+
+   * :ref:`tutorial-cylc-family-triggers` - contains examples of tasks with
+     optional outputs.
+
    Major Changes:
 
    * :ref:`728.suicide_triggers`
@@ -330,7 +335,10 @@ Cylc Install
 
 .. seealso::
 
-   :ref:`Moving to Cylc Install<majorchangesinstall>`.
+   * :ref:`Moving to Cylc Install<majorchangesinstall>`.
+   * :ref:`tutorials.furthertopics` have been re-written to use cylc install.
+   * :ref:`tutorial.furthertopics.queues` provides an example of using
+     named runs.
 
 
 Cylc install cleanly separates workflow source directory from run directory,

--- a/src/tutorial/furthertopics/broadcast.rst
+++ b/src/tutorial/furthertopics/broadcast.rst
@@ -20,7 +20,7 @@ runs on.
 Standalone Example
 ------------------
 
-Create a new workflow in the ``cylc-run`` directory called
+Create a new workflow in the ``cylc-src`` directory called
 ``tutorial-broadcast``::
 
    mkdir ~/cylc-src/tutorial-broadcast

--- a/src/tutorial/furthertopics/broadcast.rst
+++ b/src/tutorial/furthertopics/broadcast.rst
@@ -23,8 +23,8 @@ Standalone Example
 Create a new workflow in the ``cylc-run`` directory called
 ``tutorial-broadcast``::
 
-   mkdir ~/cylc-run/tutorial-broadcast
-   cd ~/cylc-run/tutorial-broadcast
+   mkdir ~/cylc-src/tutorial-broadcast
+   cd ~/cylc-src/tutorial-broadcast
 
 Copy the following configuration into a :cylc:conf:`flow.cylc` file:
 
@@ -69,6 +69,7 @@ whilst the workflow is running. For instance we could change the value of the
 Run the workflow then try using the ``cylc broadcast`` command to change the
 message::
 
+   cylc install
    cylc play tutorial-broadcast
    cylc broadcast tutorial-broadcast -n announce -s "[environment]WORD=it"
 

--- a/src/tutorial/furthertopics/broadcast.rst
+++ b/src/tutorial/furthertopics/broadcast.rst
@@ -69,6 +69,7 @@ whilst the workflow is running. For instance we could change the value of the
 Run the workflow then try using the ``cylc broadcast`` command to change the
 message::
 
+   cylc validate .
    cylc install
    cylc play tutorial-broadcast
    cylc broadcast tutorial-broadcast -n announce -s "[environment]WORD=it"
@@ -119,7 +120,8 @@ Add the following runtime configuration to the ``runtime`` section:
            [[[environment]]]
                WORDS = ni, it, ekke ekke ptang zoo boing
 
-Run the workflow and inspect the log. You should see the message change randomly
+Re-install and run the workflow, and inspect the log.
+You should see the message change randomly
 after every third entry (because the ``change_word`` task runs every 3 hours)
 e.g::
 

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -161,7 +161,7 @@ Save your changes, install and run your workflow using::
 
 Again, notice how the tasks trigger until the current time is reached.
 
-eave your workflow running for a while to confirm it is working as expected
+Leave your workflow running for a while to confirm it is working as expected
 before stopping it.
 
 

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -38,11 +38,11 @@ Example
 
 Our example workflow will simulate a clock chiming on the hour.
 
-Within your ``~/cylc-run`` directory create a new directory called
+Within your ``~/cylc-src`` directory create a new directory called
 ``clock-trigger``::
 
-   mkdir ~/cylc-run/clock-trigger
-   cd ~/cylc-run/clock-trigger
+   mkdir ~/cylc-src/clock-trigger
+   cd ~/cylc-src/clock-trigger
 
 Paste the following code into a ``flow.cylc`` file:
 
@@ -72,14 +72,12 @@ of times equal to the (cycle point) hour.
 
 Run your workflow using::
 
+   cylc install
    cylc play clock-trigger
 
 Stop the workflow after a few cycles using ``cylc stop --now --now clock-trigger``.
 Notice how the tasks run as soon as possible rather than
 waiting for the actual time to be equal to the cycle point.
-
-.. TODO - check this tutorial still works now that cylc run/restart has been
-   replaced by cylc play
 
 
 Clock-Triggering Tasks
@@ -98,7 +96,7 @@ your ``flow.cylc``:
 This tells the workflow to clock trigger the ``bell`` task with a cycle
 offset of ``0`` hours.
 
-Save your changes and run your workflow.
+Save your changes, install and run your workflow.
 
 Your workflow should now be running the ``bell`` task in real-time. Any cycle times
 that have already passed (such as the one defined by ``initial cycle time``)
@@ -133,6 +131,8 @@ Edit the ``[[scheduling]]`` section to read:
 
 .. code-block:: cylc
 
+   initial cycle point = now
+   final cycle point = +P1D # Run for one day
    [[xtriggers]]
        quarter_past_trigger = wall_clock(offset=PT15M):PT30S
        half_past_trigger = wall_clock(offset=PT30M):PT30S
@@ -147,14 +147,14 @@ Edit the ``[[scheduling]]`` section to read:
 
 Note the different values used for the cycle offsets of the clock-trigger tasks.
 
-Save your changes and run your workflow using::
+Save your changes, install and run your workflow using::
 
-   cylc play clock-trigger now
+   cylc install; cylc play clock-trigger
 
 .. note::
 
-   The ``now`` argument will run your workflow using the current time for the
-   initial cycle point.
+   Setting ``initial cycle point = now`` will run your workflow using the
+   current time at startup as the initial cycle point.
 
 Again, notice how the tasks trigger until the current time is reached.
 

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -161,9 +161,8 @@ Save your changes, install and run your workflow using::
 
 Again, notice how the tasks trigger until the current time is reached.
 
-Leave your workflow running for a while to confirm it is working as expected
-and then shut it down using the :guilabel:`stop` button in the
-:ref:`tutorial.gui`.
+eave your workflow running for a while to confirm it is working as expected
+before stopping it.
 
 
 .. note::

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -162,7 +162,8 @@ Save your changes, install and run your workflow using::
 Again, notice how the tasks trigger until the current time is reached.
 
 Leave your workflow running for a while to confirm it is working as expected
-and then shut it down using the :guilabel:`stop` button in the ``cylc gui``.
+and then shut it down using the :guilabel:`stop` button in the
+:ref:`tutorial.gui`.
 
 
 .. note::

--- a/src/tutorial/furthertopics/clock-triggered-tasks.rst
+++ b/src/tutorial/furthertopics/clock-triggered-tasks.rst
@@ -72,6 +72,7 @@ of times equal to the (cycle point) hour.
 
 Run your workflow using::
 
+   cylc validate .
    cylc install
    cylc play clock-trigger
 
@@ -149,7 +150,9 @@ Note the different values used for the cycle offsets of the clock-trigger tasks.
 
 Save your changes, install and run your workflow using::
 
-   cylc install; cylc play clock-trigger
+   cylc validate .
+   cylc install
+   cylc play clock-trigger
 
 .. note::
 

--- a/src/tutorial/furthertopics/family-triggers.rst
+++ b/src/tutorial/furthertopics/family-triggers.rst
@@ -87,8 +87,10 @@ You have now created a workflow that:
   or fails.
 * Has 7 tasks that inherit from the ``MINERS`` family.
 
-Run the workflow::
+Validate, install and run the workflow::
 
+   cylc validate .
+   cylc install
    cylc play tutorial-family-triggers
 
 You should see the ``visit_mine`` task run, then trigger the members of the

--- a/src/tutorial/furthertopics/family-triggers.rst
+++ b/src/tutorial/furthertopics/family-triggers.rst
@@ -22,11 +22,17 @@ that the dependency refers to the ``succeed`` state e.g:
 .. code-block:: cylc-graph
 
    bake_bread => sell_bread          # sell_bread is dependent on bake_bread succeeding.
-   bake_bread:succeed => sell_bread  # sell_bread is dependent on bake_bread succeeding.
-   sell_bread:fail => through_away   # through_away is dependent on sell_bread failing.
+   bake_bread:succeed => sell_bread?  # sell_bread is dependent on bake_bread succeeding.
+   sell_bread:fail? => throw_away   # through_away is dependent on sell_bread failing.
 
 The left-hand side of a :term:`dependency` (e.g. ``sell_bread:fail``) is
 referred to as the :term:`trigger <task trigger>`.
+
+.. versionchanged:: 8.0.0
+
+   ``sell_bread(:succeed)`` and ``sell_bread:fail`` are mutually exclusive
+   outcomes. To tell Cylc use the ``?`` syntax to mark them as
+   :ref:`optional outputs`.
 
 When we write a trigger involving a family, special qualifiers are required
 to specify whether the dependency is concerned with *all* or *any* of the tasks
@@ -45,8 +51,8 @@ Example
 
 Create a new workflow called ``tutorial-family-triggers``::
 
-   mkdir ~/cylc-run/tutorial-family-triggers
-   cd ~/cylc-run/tutorial-family-triggers
+   mkdir ~/cylc-src/tutorial-family-triggers
+   cd ~/cylc-src/tutorial-family-triggers
 
 Paste the following configuration into the :cylc:conf:`flow.cylc` file:
 
@@ -113,8 +119,8 @@ this:
 
    [[graph]]
        R1 = """
-           visit_mine => MINERS
-           MINERS:finish-all & MINERS:succeed-any => sell_diamonds
+           visit_mine => MINERS?
+           MINERS:finish-all & MINERS:succeed-any? => sell_diamonds
        """
 
 Then, add the following task to the ``[runtime]`` section:
@@ -149,10 +155,9 @@ this:
 
    [[graph]]
        R1 = """
-           visit_mine => MINERS
-           MINERS:finish-all & MINERS:succeed-any => sell_diamonds
-           MINERS:finish-all & MINERS:fail-any => close_shafts
-           close_shafts => !MINERS
+           visit_mine => MINERS?
+           MINERS:finish-all & MINERS:succeed-any? => sell_diamonds
+           MINERS:finish-all & MINERS:fail-any? => close_shafts
        """
 
 Alter the ``[[sell_diamonds]]`` section to look like this:
@@ -163,7 +168,7 @@ Alter the ``[[sell_diamonds]]`` section to look like this:
        script = sleep 5
 
 These changes add a ``close_shafts`` task which is run once all the
-``MINERS`` tasks have finished and any of them have failed. 
+``MINERS`` tasks have finished and any of them have failed.
 
 Save your changes and run your workflow. You should see the new
 ``close_shafts`` run should any of the ``MINERS`` tasks be in the failed

--- a/src/tutorial/furthertopics/family-triggers.rst
+++ b/src/tutorial/furthertopics/family-triggers.rst
@@ -31,7 +31,8 @@ referred to as the :term:`trigger <task trigger>`.
 .. note::
 
    ``sell_bread(:succeed)`` and ``sell_bread:fail`` are mutually exclusive
-   outcomes. To tell Cylc use the ``?`` syntax to mark them as
+   outcomes. As both appear in the graph above, it is
+   necessary to use the ``?`` syntax to mark them as
    :ref:`optional outputs`.
 
 When we write a trigger involving a family, special qualifiers are required

--- a/src/tutorial/furthertopics/family-triggers.rst
+++ b/src/tutorial/furthertopics/family-triggers.rst
@@ -21,14 +21,14 @@ that the dependency refers to the ``succeed`` state e.g:
 
 .. code-block:: cylc-graph
 
-   bake_bread => sell_bread          # sell_bread is dependent on bake_bread succeeding.
+   bake_bread => sell_bread           # sell_bread is dependent on bake_bread succeeding.
    bake_bread:succeed => sell_bread?  # sell_bread is dependent on bake_bread succeeding.
-   sell_bread:fail? => throw_away   # through_away is dependent on sell_bread failing.
+   sell_bread:fail? => throw_away     # throw_away is dependent on sell_bread failing.
 
 The left-hand side of a :term:`dependency` (e.g. ``sell_bread:fail``) is
 referred to as the :term:`trigger <task trigger>`.
 
-.. versionchanged:: 8.0.0
+.. note::
 
    ``sell_bread(:succeed)`` and ``sell_bread:fail`` are mutually exclusive
    outcomes. To tell Cylc use the ``?`` syntax to mark them as

--- a/src/tutorial/furthertopics/family-triggers.rst
+++ b/src/tutorial/furthertopics/family-triggers.rst
@@ -140,6 +140,10 @@ Save your changes and run your workflow. You should see the new
 ``sell_diamonds`` task being run once all the miners have finished and at
 least one of them has succeeded. Stop your workflow as described above.
 
+.. seealso::
+
+   User guide on
+   :ref:`family triggers and optional outputs<optional outputs.family triggers>`.
 
 Family Triggering: Failure
 --------------------------

--- a/src/tutorial/furthertopics/index.rst
+++ b/src/tutorial/furthertopics/index.rst
@@ -1,3 +1,5 @@
+.. _tutorials.furthertopics:
+
 Further Topics
 ==============
 

--- a/src/tutorial/furthertopics/inheritance.rst
+++ b/src/tutorial/furthertopics/inheritance.rst
@@ -16,8 +16,8 @@ Inheritance Hierarchy
 Within your ``~/cylc-run`` directory create a new directory called
 ``inheritance-tutorial``::
 
-   mkdir ~/cylc-run/inheritance-tutorial
-   cd ~/cylc-run/inheritance-tutorial
+   mkdir ~/cylc-src/inheritance-tutorial
+   cd ~/cylc-src/inheritance-tutorial
 
 And paste the following code into a ``flow.cylc`` file. This
 defines two tasks each representing different aircraft, the Airbus A380 jumbo
@@ -74,7 +74,7 @@ jet and the Robson R44 helicopter:
    The ``[meta]`` section is a freeform section where we can define metadata
    to be associated with a task, family or the workflow itself.
 
-   This metadata should not be mistaken with Rose :ref:`conf-meta`.
+   This metadata should not be mistaken for Rose :ref:`conf-meta`.
 
 .. admonition:: Reminder
    :class: hint
@@ -183,7 +183,7 @@ Add the following task to your :cylc:conf:`flow.cylc` file.
            [[[meta]]]
                title = V-22 Osprey Military Aircraft.
 
-Refresh your ``cylc graph`` window or re-run the ``cylc graph`` command.
+Re-run the ``cylc graph`` command.
 
 The inheritance hierarchy should now look like this:
 

--- a/src/tutorial/furthertopics/inheritance.rst
+++ b/src/tutorial/furthertopics/inheritance.rst
@@ -13,7 +13,7 @@ multiple inheritance.
 Inheritance Hierarchy
 ---------------------
 
-Within your ``~/cylc-run`` directory create a new directory called
+Within your ``~/cylc-src`` directory create a new directory called
 ``inheritance-tutorial``::
 
    mkdir ~/cylc-src/inheritance-tutorial

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -335,14 +335,8 @@ triggers another task bar and when fully completed triggers another task, baz.
 
    #. **Install and Play the workflow.**
 
-      Now we are ready to run our workflow. Open the Cylc GUI by running the
-      following command in a new terminal:
-
-      .. code-block:: bash
-
-         cylc gui
-
-      Validate, install and play the workflow:
+      Now we are ready to run our workflow. Open the :ref:`tutorial.gui` or
+      :ref:`tutorial.tui`, then validate, install and play the workflow.
 
       .. code-block:: bash
 

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -342,10 +342,11 @@ triggers another task bar and when fully completed triggers another task, baz.
 
          cylc gui
 
-      Install and play the workflow:
+      Validate, install and play the workflow:
 
       .. code-block:: bash
 
+         cylc validate .
          cylc install
          cylc play message-triggers
 

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -335,8 +335,9 @@ triggers another task bar and when fully completed triggers another task, baz.
 
    #. **Install and Play the workflow.**
 
-      Now we are ready to run our workflow. Open the :ref:`tutorial.gui` or
-      :ref:`tutorial.tui`, then validate, install and play the workflow.
+      Now we are ready to run our workflow. Validate, install, then open
+      the :ref:`GUI <tutorial.gui>` or :ref:`TUI <tutorial.tui>` and play
+      the workflow.
 
       .. code-block:: bash
 

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -285,10 +285,10 @@ triggers another task bar and when fully completed triggers another task, baz.
          .. code-block:: cylc
 
             [meta]
-            title = "test workflow to demo message triggers"
+                title = "test workflow to demo message triggers"
 
             [scheduler]
-            UTC mode = True
+                UTC mode = True
 
             [scheduling]
                 initial cycle point = 2019-06-27T00Z
@@ -387,9 +387,9 @@ triggers another task bar and when fully completed triggers another task, baz.
          .. code-block:: cylc
 
             [scheduler]
-            UTC mode = True
+                UTC mode = True
             [meta]
-            title = "test workflow to demo message triggers"
+                title = "test workflow to demo message triggers"
             [scheduling]
                 initial cycle point = 2019-06-27T00Z
                 final cycle point = 2019-10-27T00Z

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -140,7 +140,7 @@ triggers another task bar and when fully completed triggers another task, baz.
          while [ $counter -le 10 ]; do
              newrand=$(( (( RANDOM % 40) + 1 ) ));
              echo $newrand >> report.txt;
-             counter=$(((counter + 1)));
+             counter=$((counter + 1));
          done
 
 

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -89,14 +89,14 @@ triggers another task bar and when fully completed triggers another task, baz.
 
    #. **Create a new directory.**
 
-      Within your ``~/cylc-run`` directory create a new directory called
+      Within your ``~/cylc-src`` directory create a new directory called
 
       ``message-triggers`` and move into it:
 
       .. code-block:: bash
 
-         mkdir ~/cylc-run/message-triggers
-         cd ~/cylc-run/message-triggers
+         mkdir ~/cylc-src/message-triggers
+         cd ~/cylc-src/message-triggers
 
    #. **Install the script needed for our workflow**
 
@@ -114,7 +114,7 @@ triggers another task bar and when fully completed triggers another task, baz.
 
       .. code-block:: bash
 
-         mkdir ~/cylc-run/message-triggers/bin
+         mkdir ~/cylc-src/message-triggers/bin
 
       Create a bash script in the bin directory:
 
@@ -133,14 +133,14 @@ triggers another task bar and when fully completed triggers another task, baz.
       .. code-block:: bash
 
          #!/usr/bin/env bash
-         set -eu
+         set -eu  # Prevent bash script failing quietly.
 
          counter=1
 
          while [ $counter -le 10 ]; do
-            newrand=$[ (( $RANDOM % 40) + 1 ) ];
-            echo $newrand >> report.txt;
-            counter=$[($counter + 1)];
+             newrand=$(( (( RANDOM % 40) + 1 ) ));
+             echo $newrand >> report.txt;
+             counter=$(((counter + 1)));
          done
 
 
@@ -150,24 +150,21 @@ triggers another task bar and when fully completed triggers another task, baz.
 
       .. code-block:: cylc
 
-         [scheduler]
-             UTC mode = True
-
          [meta]
              title = "test workflow to demo message triggers"
+
+         [scheduler]
+             UTC mode = True
 
          [scheduling]
              initial cycle point = 2019-06-27T00Z
              final cycle point = 2019-10-27T00Z
-
-             [[dependencies]]
-
-                 [[[P2M]]]
-                     graph = """
-                         long_forecasting_task =>  another_weather_task
-                         long_forecasting_task => different_weather_task
-                         long_forecasting_task[-P2M] => long_forecasting_task
-                     """
+             [[graph]]
+                 P2M = """
+                     long_forecasting_task =>  another_weather_task
+                     long_forecasting_task => different_weather_task
+                     long_forecasting_task[-P2M] => long_forecasting_task
+                 """
 
       This is a basic workflow, currently it does not have any message triggers
       attached to any task.
@@ -252,11 +249,11 @@ triggers another task bar and when fully completed triggers another task, baz.
                      sleep 2
                      random.sh
          +           cylc message -- "${CYLC_WORKFLOW_ID}" "${CYLC_TASK_JOB}" \
-                          "Task partially complete, report ready to view"
+         +                "Task partially complete, report ready to view"
                      sleep 2
                      random.sh
          +           cylc message -- "${CYLC_WORKFLOW_ID}" "${CYLC_TASK_JOB}" \
-                          "Task partially complete, report updated"
+         +               "Task partially complete, report updated"
                      sleep 2
                      random.sh
                  """
@@ -287,27 +284,24 @@ triggers another task bar and when fully completed triggers another task, baz.
 
          .. code-block:: cylc
 
-            [scheduler]
-            UTC mode = True
-
             [meta]
             title = "test workflow to demo message triggers"
+
+            [scheduler]
+            UTC mode = True
 
             [scheduling]
                 initial cycle point = 2019-06-27T00Z
                 final cycle point = 2019-10-27T00Z
 
-                [[dependencies]]
-
-                    [[[P2M]]]
-                        graph = """
-                            long_forecasting_task:update1 =>  another_weather_task
-                            long_forecasting_task:update2 => different_weather_task
-                            long_forecasting_task[-P2M] => long_forecasting_task
-                        """
+                [[graph]]
+                    P2M = """
+                        long_forecasting_task:update1 =>  another_weather_task
+                        long_forecasting_task:update2 => different_weather_task
+                        long_forecasting_task[-P2M] => long_forecasting_task
+                    """
 
             [runtime]
-
                 [[long_forecasting_task]]
                     script = """
                         sleep 2
@@ -321,7 +315,6 @@ triggers another task bar and when fully completed triggers another task, baz.
                         sleep 2
                         random.sh
                     """
-
                     [[[outputs]]]
                         update1 = "Task partially complete, report ready to view"
                         update2 = "Task partially complete, report updated"
@@ -340,20 +333,20 @@ triggers another task bar and when fully completed triggers another task, baz.
 
           cylc validate .
 
-   #. **Run the workflow.**
+   #. **Install and Play the workflow.**
 
       Now we are ready to run our workflow. Open the Cylc GUI by running the
-      following command:
+      following command in a new terminal:
 
       .. code-block:: bash
 
-         cylc gui message-triggers &
+         cylc gui
 
-      Run the workflow either by pressing the play button in the Cylc GUI or by
-      running the command:
+      Install and play the workflow:
 
       .. code-block:: bash
 
+         cylc install
          cylc play message-triggers
 
       Your workflow should now run, the tasks should succeed.

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -65,8 +65,9 @@ And paste the following into :cylc:conf:`flow.cylc`:
 
    ``|`` (or), and ``=>`` act in the same way.
 
-Install and play the workflow, then open the ``cylc gui``::
+Validate, install and play the workflow, then open the ``cylc gui``::
 
+   cylc validate .
    cylc install --run-name without-queues
    cylc play queues-tutorial/without-queues
    cylc gui
@@ -98,6 +99,7 @@ section like so:
 
 Install and play the workflow then open up the GUI (if you closed it)::
 
+   cylc validate .
    cylc install --run-name tutorial-with-queues
    cylc play queues-tutorial/with-queues
    cylc gui

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -69,16 +69,17 @@ Validate, install and play the workflow::
 
    cylc validate .
    cylc install --run-name without-queues
-   cylc play queues-tutorial/without-queues
 
 Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
+
+Play the workflow, either from the GUI or the command line::
+
+   cylc play queues-tutorial/without-queues
 
 You will see that all the ``steak``, ``pasta``, and ``pizza`` tasks are run
 at once, swiftly followed by all the ``ice_cream``, ``cheesecake``,
 ``sticky_toffee`` tasks as the customers order from the dessert menu.
 
-(If you aren't very quick starting the GUI you may find that the entire
-workflow has already run by the time you navigate to it.)
 
 This will overwhelm our restaurant staff! The chef responsible for ``MAINS``
 can only handle 3 tasks at any given time, and the ``DESSERT`` chef can only

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -49,26 +49,32 @@ And paste the following into :cylc:conf:`flow.cylc`:
 
 .. note::
 
-   In graph sections backslash (``\``) is a line continuation character i.e. the
+   In graph sections ``&`` is a line continuation character i.e. the
    following two examples are equivalent:
 
    .. code-block:: cylc
 
-      foo => bar & \
+      foo => bar &
              baz
 
    .. code-block:: cylc
 
       foo => bar & baz
 
-Open the ``cylc gui`` then run the workflow::
+   ``|`` (or), and ``=>`` act in the same way.
 
-   cylc gui queues-tutorial &
-   cylc play queues-tutorial
+Install and play the workflow, then open the ``cylc gui``::
+
+   cylc install --run-name without-queues
+   cylc play queues-tutorial/without-queues
+   cylc gui
 
 You will see that all the ``steak``, ``pasta``, and ``pizza`` tasks are run
 at once, swiftly followed by all the ``ice_cream``, ``cheesecake``,
 ``sticky_toffee`` tasks as the customers order from the dessert menu.
+
+(If you aren't very quick starting the GUI you may find that the entire
+workflow has already run by the time you navigate to it.)
 
 This will overwhelm our restaurant staff! The chef responsible for ``MAINS``
 can only handle 3 tasks at any given time, and the ``DESSERT`` chef can only
@@ -88,7 +94,12 @@ section like so:
                limit = 2  # Only 2 dessert dishes at one time.
                members = DESSERT
 
-Re-open the ``cylc gui`` if you have closed it and re-run the workflow.
+Install and play the workflow then open up the GUI (if you closed it)::
+
+   cylc install --run-name tutorial-with-queues
+   cylc play queues-tutorial/with-queues
+   cylc gui
+
 
 You should see that there are now never more than 3 active ``MAINS`` tasks
 running and never more than 2 active ``DESSERT`` tasks running.

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -102,9 +102,9 @@ Install and play the workflow::
 
    cylc validate .
    cylc install --run-name tutorial-with-queues
-   cylc play queues-tutorial/with-queues
 
-Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
+Play the workflow using the ref:`GUI <tutorial.gui>`
+or :ref:`TUI <tutorial.tui>`.
 
 You should see that there are now never more than 3 active ``MAINS`` tasks
 running and never more than 2 active ``DESSERT`` tasks running.

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -103,7 +103,7 @@ Install and play the workflow::
    cylc validate .
    cylc install --run-name tutorial-with-queues
 
-Play the workflow using the ref:`GUI <tutorial.gui>`
+Play the workflow using the :ref:`GUI <tutorial.gui>`
 or :ref:`TUI <tutorial.tui>`.
 
 You should see that there are now never more than 3 active ``MAINS`` tasks

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -65,12 +65,13 @@ And paste the following into :cylc:conf:`flow.cylc`:
 
    ``|`` (or), and ``=>`` act in the same way.
 
-Validate, install and play the workflow, then open the ``cylc gui``::
+Validate, install and play the workflow::
 
    cylc validate .
    cylc install --run-name without-queues
    cylc play queues-tutorial/without-queues
-   cylc gui
+
+Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
 
 You will see that all the ``steak``, ``pasta``, and ``pizza`` tasks are run
 at once, swiftly followed by all the ``ice_cream``, ``cheesecake``,
@@ -97,13 +98,13 @@ section like so:
                limit = 2  # Only 2 dessert dishes at one time.
                members = DESSERT
 
-Install and play the workflow then open up the GUI (if you closed it)::
+Install and play the workflow::
 
    cylc validate .
    cylc install --run-name tutorial-with-queues
    cylc play queues-tutorial/with-queues
-   cylc gui
 
+Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
 
 You should see that there are now never more than 3 active ``MAINS`` tasks
 running and never more than 2 active ``DESSERT`` tasks running.

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -51,7 +51,7 @@ And paste the following into :cylc:conf:`flow.cylc`:
 
 .. note::
 
-   In graph sections ``&`` is a line continuation character i.e. the
+   In graph sections, lines can be split on ``&``, i.e. the
    following two examples are equivalent:
 
    .. code-block:: cylc-graph

--- a/src/tutorial/furthertopics/queues.rst
+++ b/src/tutorial/furthertopics/queues.rst
@@ -1,3 +1,5 @@
+.. _tutorial.furthertopics.queues:
+
 Queues
 ======
 
@@ -52,12 +54,12 @@ And paste the following into :cylc:conf:`flow.cylc`:
    In graph sections ``&`` is a line continuation character i.e. the
    following two examples are equivalent:
 
-   .. code-block:: cylc
+   .. code-block:: cylc-graph
 
       foo => bar &
              baz
 
-   .. code-block:: cylc
+   .. code-block:: cylc-graph
 
       foo => bar & baz
 

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -71,11 +71,9 @@ Let's see what happens when we run the workflow as it is. Open the
 
 Then install and run the workflow::
 
+   cylc validate .
    cylc install
    cylc play retries-tutorial
-
-.. TODO - check this tutorial still works now that cylc run/restart has been
-   replaced by cylc play
 
 Unless you're lucky, the workflow should fail at the roll_doubles task.
 
@@ -117,6 +115,7 @@ If you closed it, re-open the ``cylc gui``::
 
 Re-install and run the workflow::
 
+   cylc validate .
    cylc install
    cylc play retries-tutorial
 

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -28,8 +28,8 @@ Example
 
 Create a new workflow by running the following commands::
 
-   mkdir -p ~/cylc-run/retries-tutorial
-   cd ~/cylc-run/retries-tutorial
+   mkdir -p ~/cylc-src/retries-tutorial
+   cd ~/cylc-src/retries-tutorial
 
 And paste the following code into a ``flow.cylc`` file. This workflow has a
 ``roll_doubles`` task that simulates trying to roll doubles using two dice:
@@ -64,12 +64,14 @@ And paste the following code into a ``flow.cylc`` file. This workflow has a
 Running Without Retries
 -----------------------
 
-Let's see what happens when we run the workflow as it is. Open the ``cylc gui``::
+Let's see what happens when we run the workflow as it is. Open the
+``cylc gui`` in a new terminal window::
 
-   cylc gui retries-tutorial &
+   cylc gui
 
-Then run the workflow::
+Then install and run the workflow::
 
+   cylc install
    cylc play retries-tutorial
 
 .. TODO - check this tutorial still works now that cylc run/restart has been
@@ -111,10 +113,11 @@ Running With Retries
 
 If you closed it, re-open the ``cylc gui``::
 
-   cylc gui retries-tutorial &
+   cylc gui
 
-Re-run the workflow::
+Re-install and run the workflow::
 
+   cylc install
    cylc play retries-tutorial
 
 What you should see is Cylc retrying the ``roll_doubles`` task. Hopefully,

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -64,12 +64,10 @@ And paste the following code into a ``flow.cylc`` file. This workflow has a
 Running Without Retries
 -----------------------
 
-Let's see what happens when we run the workflow as it is. Open the
-``cylc gui`` in a new terminal window::
+Let's see what happens when we run the workflow as it is.
+Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
 
-   cylc gui
-
-Then install and run the workflow::
+Then validate install and run the workflow::
 
    cylc validate .
    cylc install
@@ -109,9 +107,7 @@ then once after one hour then once after three hours.
 Running With Retries
 --------------------
 
-If you closed it, re-open the ``cylc gui``::
-
-   cylc gui
+Look at the workflow with :ref:`tutorial.gui` or :ref:`tutorial.tui`
 
 Re-install and run the workflow::
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1640,6 +1640,7 @@ is optional" and that a non-optional version of the trigger makes sense.
       foo => baz  # ERROR : foo:succeed must be optional here!
    """
 
+.. _optional outputs.family triggers:
 
 Family Triggers
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update the furthertopics tutorials for Cylc 8.

Similar to, but not actually overlapping #383 

#### Notable changes
- [x] Replace develop in `~/cylc-run/tutorial-name` with develop in `~/cylc-src` and accompanying "validate; install; play"  workflow.
- [x] Updated Cylc 7 `[scheduling][dependencies][<RECUR>]graph` syntax in message triggers tutorial.
- [x] Updated the family triggers tutorial to use optional outputs syntax - workflow wouldn't validate else. 

