### PR TITLE
Create reference section for job script environment variables

### DIFF
--- a/src/reference/index.rst
+++ b/src/reference/index.rst
@@ -5,8 +5,9 @@ Reference
 .. toctree::
    :maxdepth: 2
 
-   architecture/index
    config/index
+   job-script-vars/index
+   architecture/index
    api/index
    environments/conda.rst
    dev-history-major-changes

--- a/src/reference/job-script-vars/index.rst
+++ b/src/reference/job-script-vars/index.rst
@@ -1,0 +1,7 @@
+Job Script Environment Variables
+================================
+
+These variables provided by the :term:`scheduler` are available to Cylc job scripts:
+
+.. literalinclude:: var-list.txt
+   :language: sub

--- a/src/reference/job-script-vars/var-list.txt
+++ b/src/reference/job-script-vars/var-list.txt
@@ -1,0 +1,56 @@
+CYLC_DEBUG                         # Debug mode, true or not defined
+CYLC_VERSION                       # Version of cylc installation used
+
+CYLC_CYCLING_MODE                  # Cycling mode, e.g. gregorian
+ISODATETIMECALENDAR                # Calendar mode for the `isodatetime` command,
+                                   #   defined with the value of CYLC_CYCLING_MODE
+                                   #   when in any datetime cycling mode
+
+CYLC_WORKFLOW_FINAL_CYCLE_POINT    # Final cycle point
+CYLC_WORKFLOW_INITIAL_CYCLE_POINT  # Initial cycle point
+CYLC_WORKFLOW_ID                   # Workflow ID
+CYLC_WORKFLOW_NAME                 # Workflow name
+                                   # (the workflow ID without the run name)
+CYLC_UTC                           # UTC mode, True or False
+CYLC_VERBOSE                       # Verbose mode, True or False
+TZ                                 # Set to "UTC" in UTC mode or not defined
+
+CYLC_WORKFLOW_RUN_DIR              # Location of the run directory in
+                                   # job host, e.g. ~/cylc-run/foo
+CYLC_WORKFLOW_HOST                 # Host running the workflow process
+CYLC_WORKFLOW_OWNER                # User ID running the workflow process
+
+CYLC_WORKFLOW_SHARE_DIR            # Workflow (or task!) shared directory (see below)
+CYLC_WORKFLOW_UUID                 # Workflow UUID string
+CYLC_WORKFLOW_WORK_DIR             # Workflow work directory (see below)
+
+CYLC_TASK_JOB                      # Task job identifier expressed as
+                                   # CYCLE-POINT/TASK-NAME/SUBMIT-NUMBER
+                                   #   e.g. 20110511T1800Z/t1/01
+
+CYLC_TASK_CYCLE_POINT              # Cycle point, e.g. 20110511T1800Z
+ISODATETIMEREF                     # Reference time for the `isodatetime` command,
+                                   #   defined with the value of CYLC_TASK_CYCLE_POINT
+                                   #   when in any datetime cycling mode
+
+CYLC_TASK_NAME                     # Job's task name, e.g. t1
+CYLC_TASK_SUBMIT_NUMBER            # Job's submit number, e.g. 1,
+                                   #   increments with every submit
+CYLC_TASK_TRY_NUMBER               # Number of execution tries, e.g. 1
+                                   #   increments with automatic retry-on-fail
+CYLC_TASK_ID                       # Task instance identifier TASK-NAME.CYCLE-POINT
+                                   #   e.g. t1.20110511T1800Z
+CYLC_TASK_LOG_DIR                  # Location of the job log directory
+                                   #   e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/
+CYLC_TASK_LOG_ROOT                 # The task job file path
+                                   #   e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/job
+CYLC_TASK_WORK_DIR                 # Location of task work directory (see below)
+                                   #   e.g. ~/cylc-run/foo/work/20110511T1800Z/t1
+CYLC_TASK_NAMESPACE_HIERARCHY      # Linearised family namespace of the task,
+                                   #   e.g. root postproc t1
+CYLC_TASK_DEPENDENCIES             # List of met dependencies that triggered the task
+                                   #   e.g. 1/foo 1/bar
+
+CYLC_TASK_COMMS_METHOD             # Set to "ssh" if communication method is "ssh"
+CYLC_TASK_SSH_LOGIN_SHELL          # With "ssh" communication, if set to "True",
+                                   #   use login shell on workflow host

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -46,8 +46,10 @@ Environment Variables
        The :term:`cycle point` for the associated task
        *(e.g. 20171009T0950)*.
 
-   There are many more environment variables - see the `Cylc User Guide`_ for more
-   information.
+   .. seealso::
+
+      There are many more environment variables - see
+      :ref:`Task Job Script Variables` for more information.
 
 .. ifslides::
 

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -290,64 +290,8 @@ Task Job Script Variables
 
 These variables provided by the :term:`scheduler` are available to task job scripts:
 
-.. code-block:: sub
-
-   CYLC_DEBUG                         # Debug mode, true or not defined
-   CYLC_VERSION                       # Version of cylc installation used
-
-   CYLC_CYCLING_MODE                  # Cycling mode, e.g. gregorian
-   ISODATETIMECALENDAR                # Calendar mode for the `isodatetime` command,
-                                      #   defined with the value of CYLC_CYCLING_MODE
-                                      #   when in any datetime cycling mode
-
-   CYLC_WORKFLOW_FINAL_CYCLE_POINT    # Final cycle point
-   CYLC_WORKFLOW_INITIAL_CYCLE_POINT  # Initial cycle point
-   CYLC_WORKFLOW_ID                   # Workflow ID
-   CYLC_WORKFLOW_NAME                 # Workflow name
-                                      # (the workflow ID without the run name)
-   CYLC_UTC                           # UTC mode, True or False
-   CYLC_VERBOSE                       # Verbose mode, True or False
-   TZ                                 # Set to "UTC" in UTC mode or not defined
-
-   CYLC_WORKFLOW_RUN_DIR              # Location of the run directory in
-                                      # job host, e.g. ~/cylc-run/foo
-   CYLC_WORKFLOW_HOST                 # Host running the workflow process
-   CYLC_WORKFLOW_OWNER                # User ID running the workflow process
-
-   CYLC_WORKFLOW_SHARE_DIR            # Workflow (or task!) shared directory (see below)
-   CYLC_WORKFLOW_UUID                 # Workflow UUID string
-   CYLC_WORKFLOW_WORK_DIR             # Workflow work directory (see below)
-
-   CYLC_TASK_JOB                      # Task job identifier expressed as
-                                      # CYCLE-POINT/TASK-NAME/SUBMIT-NUMBER
-                                      #   e.g. 20110511T1800Z/t1/01
-
-   CYLC_TASK_CYCLE_POINT              # Cycle point, e.g. 20110511T1800Z
-   ISODATETIMEREF                     # Reference time for the `isodatetime` command,
-                                      #   defined with the value of CYLC_TASK_CYCLE_POINT
-                                      #   when in any datetime cycling mode
-
-   CYLC_TASK_NAME                     # Job's task name, e.g. t1
-   CYLC_TASK_SUBMIT_NUMBER            # Job's submit number, e.g. 1,
-                                      #   increments with every submit
-   CYLC_TASK_TRY_NUMBER               # Number of execution tries, e.g. 1
-                                      #   increments with automatic retry-on-fail
-   CYLC_TASK_ID                       # Task instance identifier TASK-NAME.CYCLE-POINT
-                                      #   e.g. t1.20110511T1800Z
-   CYLC_TASK_LOG_DIR                  # Location of the job log directory
-                                      #   e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/
-   CYLC_TASK_LOG_ROOT                 # The task job file path
-                                      #   e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/job
-   CYLC_TASK_WORK_DIR                 # Location of task work directory (see below)
-                                      #   e.g. ~/cylc-run/foo/work/20110511T1800Z/t1
-   CYLC_TASK_NAMESPACE_HIERARCHY      # Linearised family namespace of the task,
-                                      #   e.g. root postproc t1
-   CYLC_TASK_DEPENDENCIES             # List of met dependencies that triggered the task
-                                      #   e.g. 1/foo 1/bar
-
-   CYLC_TASK_COMMS_METHOD             # Set to "ssh" if communication method is "ssh"
-   CYLC_TASK_SSH_LOGIN_SHELL          # With "ssh" communication, if set to "True",
-                                      #   use login shell on workflow host
+.. literalinclude:: ../../reference/job-script-vars/var-list.txt
+   :language: sub
 
 Some global shell variables are also defined in the task job script, but not
 exported to subshells:


### PR DESCRIPTION
After struggling to find the list of job env vars for a while, I thought it would be a good idea to create a section for it in the reference part of the docs.