### PR TITLE
Fix build error due to intersphinx failing to find zmq class

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -130,6 +130,11 @@ linkcheck_ignore = [
     r'https://github.com/metomi/isodatetime.*#.*'
 ]
 
+nitpick_ignore_regex = [
+    # intersphinx has trouble with pyzmq classes:
+    ('py:class', 'zmq\.asyncio\.\w+')
+]
+
 # -- Options for Slides output ----------------------------------------------
 
 slide_theme = 'single-level'


### PR DESCRIPTION
Fixes
```
Warning, treated as error:
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/cylc/flow/network/client.py:docstring of
    cylc.flow.network.client.WorkflowRuntimeClient::py:class reference target not found: zmq.asyncio.Context
make: *** [html] Error 2
Makefile:57: recipe for target 'html' failed
```
Better solution than https://github.com/cylc/cylc-flow/pull/4692 as it allows us to keep the type annotations

Sibling: https://github.com/cylc/cylc-flow/pull/4693 (but this needs merging first)