### PR TITLE
Revert markupsafe thingies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,8 @@ jobs:
           pip install  \
             "cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@${cylc_flow}" \
             "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}" \
-            "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}"
-          git clone --depth 1 --branch "${meto_rose}" https://github.com/metomi/rose ../rose
-          pip install -e ../rose[all]
+            "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}" \
+            "metomi-rose[all] @ git+https://github.com/metomi/rose@${meto_rose}"
 
       - name: install eslint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,11 @@ jobs:
         run: |
           # NOTE: Install with [all] so we can import plugins which may
           #       have extra dependencies.
-          pip install  \
+          pip install \
             "cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@${cylc_flow}" \
-            "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}" \
             "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}" \
-            "metomi-rose[all] @ git+https://github.com/metomi/rose@${meto_rose}"
+            "metomi-rose[all] @ git+https://github.com/metomi/rose@${meto_rose}" \
+            "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}"
 
       - name: install eslint
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ install_requires =
     sphinx>=4.4
     sphinx_rtd_theme>=0.5.0
     sphinxcontrib-svg2pdfconverter
-    markupsafe<2.1  # remove me once patched in cylc-flow
 
 [options.packages.find]
 include = cylc*

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -36,15 +36,9 @@ Via Pip (+npm)
 
    We recommend using a virtual environment.
 
-.. warning::
-
-   If using ``pip`` to install Cylc versions 8.0rc1 and below, a bug in
-   Jinja2 means you will have to manually install ``markupsafe`` at less
-   than version 2.1.
-
 .. code-block:: sub
 
-   $ pip install 'markupsafe<2.1' cylc-flow
+   $ pip install cylc-flow
 
    # install the browser-GUI (optional)
    # (requires nodejs & npm)


### PR DESCRIPTION
No longer needed as we have pinned markupsafe to a max version in 8.0rc2.dev