### PR TITLE
Fix tutorial table formatting.

### DIFF
--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -118,6 +118,7 @@ Duplicate settings get overwritten:
          a = foo
          a = bar  # duplicate
 
+     -
       .. code-block:: cylc
          :caption: result
 


### PR DESCRIPTION
A trivial fix: table columns weren't side-by-side as intended.