### PR TITLE
Improve readability of diagram

### DIFF
--- a/src/user-guide/task-implementation/job-scripts.rst
+++ b/src/user-guide/task-implementation/job-scripts.rst
@@ -44,44 +44,44 @@ finish, unless you start it with the ``wait`` command to prevent that.
 
 .. digraph:: example
 
-    rankdir="LR"
-    packmode="array_u";
+   rankdir="TB"
+   packmode="array_u";
 
-    subgraph cluster_legend {
-        style="dashed"
-        label="Legend"
+   subgraph cluster_legend {
+       style="dashed"
+       label="Legend"
 
-        "user defined script"
-        "cylc defined script" [shape="rect"]
+       "user defined script"
+       "cylc defined script" [shape="rect"]
 
-        "user defined script" -> "cylc defined script" [style="invis"]
-    }
+       "user defined script" -> "cylc defined script" [style="invis"]
+   }
 
-    subgraph cluster_diagram {
-        style="invis"
-        margin=20
+   subgraph cluster_diagram {
+       style="invis"
+       margin=20
 
-        "cylc-env" [shape="rect"]
-        "user-env" [shape="rect"]
+       "cylc-env" [shape="rect"]
+       "user-env" [shape="rect"]
 
-        "init-script" ->
-        "cylc-env" ->
-        "env-script"
+       "init-script" ->
+       "cylc-env" ->
+       "env-script"
 
-        subgraph cluster_subshell {
-            style="dashed"
-            label="Subshell process"
+       subgraph cluster_subshell {
+           style="dashed"
+           label="Subshell process"
 
-            "env-script" ->
-            "user-env" ->
-            "pre-script" ->
-            "script" ->
-            "post-script"
-        }
+           "env-script" ->
+           "user-env" ->
+           "pre-script" ->
+           "script" ->
+           "post-script"
+       }
 
-        "post-script" -> "err-script"
-        "post-script" -> "exit-script"
-    }
+       "post-script" -> "err-script"
+       "post-script" -> "exit-script"
+   }
 
 The two "Cylc defined scripts" are:
 


### PR DESCRIPTION
### Before:

![image](https://user-images.githubusercontent.com/61982285/157446663-ebd3e3a8-c815-4183-9452-c89ca549424e.png)

### After:

![image](https://user-images.githubusercontent.com/61982285/157446704-4b403090-9646-4939-98e8-81094c5f5478.png)


(I realise it's a little too big for comfort now, but can't seem to find a simple solution?)