### PR TITLE
Fix nightly

### DIFF
--- a/.github/actions/create-conda-envs/action.yml
+++ b/.github/actions/create-conda-envs/action.yml
@@ -39,7 +39,7 @@ runs:
           # TODO: add explicit python dep
           sed \
             -e 's/python =.*/python =${{ inputs.python_version }}/' \
-            -e "s/|release|/${CYLC_RELEASE}/" \
+            -e "s/|version|/${CYLC_RELEASE}/" \
             "${env_file}" \
             > "${new_env_file}"
           # create the env

--- a/.github/actions/install-libs/action.yml
+++ b/.github/actions/install-libs/action.yml
@@ -1,0 +1,36 @@
+name: Install libs to document
+description: Install Cylc libs and Rose
+
+inputs:
+  # If these are not specified, they fall back to the workflow_dispatch input
+  # values, or failing that, 'master'
+  cylc-flow-tag:
+    description: 'cylc-flow github release tag (must be present in cylc-docs)'
+    required: false
+  cylc-rose-tag:
+    description: 'cylc-rose github release tag'
+    required: false
+  cylc-uis-tag:
+    description: 'cylc-uiserver github release tag'
+    required: false
+  metomi-rose-tag:
+    description: 'rose github release tag (currently only affects cylc-rose install)'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        cylc_flow: ${{ inputs.cylc-flow-tag || github.event.inputs.cylc-flow-tag || 'master' }}
+        meto_rose: ${{ inputs.metomi-rose-tag || github.event.inputs.metomi-rose-tag || 'master' }}
+        cylc_rose: ${{ inputs.cylc-rose-tag || github.event.inputs.cylc-rose-tag || 'master' }}
+        cylc_uis: ${{ inputs.cylc-uis-tag || github.event.inputs.cylc-uis-tag || 'master' }}
+      run: |
+        pip install \
+          "cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@${cylc_flow}" \
+          "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}" \
+          "metomi-rose[all] @ git+https://github.com/metomi/rose@${meto_rose}" \
+          "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}"
+      # NOTE: Install with [all] so we can import plugins which may
+      # have extra dependencies.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ on:
         description: "Don't fail if the conda environments fail to build."
         type: boolean
         default: false
+        required: false
 
 jobs:
   deploy:
@@ -74,20 +75,7 @@ jobs:
         run: pip install "${{ github.workspace }}/docs[all]"
 
       - name: install libs to document
-        env:
-          cylc_flow: ${{ github.event.inputs.cylc-flow-tag }}
-          meto_rose: ${{ github.event.inputs.metomi-rose-tag }}
-          cylc_rose: ${{ github.event.inputs.cylc-rose-tag }}
-          cylc_uis: ${{ github.event.inputs.cylc-uis-tag }}
-        run: |
-          # NOTE: Install with [all] so we can import plugins which may
-          #       have extra dependencies.
-          pip install  \
-            "cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@${cylc_flow}" \
-            "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}" \
-            "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}"
-          git clone --depth 1 --branch "${meto_rose}" https://github.com/metomi/rose ../rose
-          pip install -e ../rose[all]
+        uses: cylc/cylc-doc/.github/actions/install-libs@master
 
       - name: create conda envs
         uses: ./docs/.github/actions/create-conda-envs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,15 +97,15 @@ jobs:
 
       - name: build docs
         run: |
+          version="nightly.$(isodatetime --utc -f %Y-%m-%d)"
           make -C docs \
             html \
             slides \
             linkcheck \
-            SPHINXOPTS='-Wn' \
+            SPHINXOPTS="-Wn -A sidebar_version_name=${version}" \
             STABLE=false \
             LATEST=false \
-            BUILDDIR='doc/nightly' \
-            CYLC_VERSION="nightly.$(isodatetime --utc -f %Y-%m-%d)"
+            BUILDDIR='doc/nightly'
           git -C gh-pages add 'nightly' 'versions.json'
 
       - name: push changes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,15 +48,7 @@ jobs:
         run: pip install "${{ github.workspace }}/docs[all]"
 
       - name: install libs to document
-        run: |
-          # NOTE: Install with [all] so we can import plugins which may
-          #       have extra dependencies.
-          pip install  \
-            'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@master' \
-            'cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@master' \
-            'cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@master'
-          git clone --depth 1 https://github.com/metomi/rose ../rose
-          pip install -e ../rose[all]
+        uses: ./docs/.github/actions/install-libs
 
       - name: checkout gh-pages branch
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,7 @@ jobs:
         run: pip install .[all]
 
       - name: install libs to document
-        env:
-          cylc_flow: ${{ github.event.inputs.cylc-flow-tag || 'master' }}
-          meto_rose: ${{ github.event.inputs.metomi-rose-tag || 'master' }}
-          cylc_rose: ${{ github.event.inputs.cylc-rose-tag || 'master' }}
-          cylc_uis: ${{ github.event.inputs.cylc-uis-tag || 'master' }}
-        run: |
-          # NOTE: Install with [all] so we can import plugins which may
-          #       have extra dependencies.
-          pip install \
-            "cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@${cylc_flow}" \
-            "cylc-uiserver[all] @ git+https://github.com/cylc/cylc-uiserver@${cylc_uis}" \
-            "metomi-rose[all] @ git+https://github.com/metomi/rose@${meto_rose}" \
-            "cylc-rose[all] @ git+https://github.com/cylc/cylc-rose@${cylc_rose}"
+        uses: ./.github/actions/install-libs
 
       - name: install eslint
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ packages = find_namespace:
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    cylc-sphinx-extensions>=1.3.4
+    cylc-sphinx-extensions>=1.3.5
     eralchemy==1.2.*
     hieroglyph>=2.1.0
     setuptools>=50

--- a/src/_templates/versions.html
+++ b/src/_templates/versions.html
@@ -9,10 +9,11 @@
 ></div>
 
 {% set ROOT_DIR = pathto('').rsplit('.html', 1)[0] + '../..' %}
+{% set CUR_VERSION = sidebar_version_name if sidebar_version_name else release %}
 
 <script type="text/javascript">
     const CUR_FORMAT = "{{ builder }}";
-    const CUR_VERSION = "{{ release }}";
+    const CUR_VERSION = "{{ CUR_VERSION }}";
     // name of page (in URL), for singlepage builds this will be `index`
     const PAGE_NAME = "{{ current_page_name }}";
     // URL path to the base docs dir i.e. ROOT_DIR/version/format

--- a/src/conf.py
+++ b/src/conf.py
@@ -165,6 +165,12 @@ html_sidebars = {
     ],
 }
 
+# Values to pass into the templating context. Can be overridden using the
+# sphinx-build opt `-A name=value` (add to SPHINXOPTS if using make).
+html_context = {
+    'sidebar_version_name': None,  # override name in version picker
+}
+
 html_static_path = ['_static']
 
 # These paths are either relative to html_static_path

--- a/src/conf.py
+++ b/src/conf.py
@@ -229,5 +229,5 @@ texinfo_show_urls = 'footnote'
 
 literal_sub_include_subs = {
     'version': version,
-    'release': release.replace('.dev', ''),
+    'release': release,
 }

--- a/src/reference/environments/envs/cylc-all.yml
+++ b/src/reference/environments/envs/cylc-all.yml
@@ -1,8 +1,8 @@
-name: cylc-|release|
+name: cylc-|version|
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|
   - cylc-uiserver
   - cylc-rose
   - metomi-rose

--- a/src/reference/environments/envs/cylc-flow-anaconda.yml
+++ b/src/reference/environments/envs/cylc-flow-anaconda.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - cylc-flow =|release|
+  - cylc-flow =|version|

--- a/src/reference/environments/envs/cylc-flow-base.yml
+++ b/src/reference/environments/envs/cylc-flow-base.yml
@@ -2,4 +2,4 @@ name: cylc-flow-base
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow-base =|release|
+  - cylc-flow-base =|version|

--- a/src/reference/environments/envs/cylc-flow-with-python.yml
+++ b/src/reference/environments/envs/cylc-flow-with-python.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python =3.7
-  - cylc-flow =|release|
+  - cylc-flow =|version|

--- a/src/reference/environments/envs/cylc-flow.yml
+++ b/src/reference/environments/envs/cylc-flow.yml
@@ -2,4 +2,4 @@ name: cylc-flow
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|

--- a/src/reference/environments/envs/cylc-rose.yml
+++ b/src/reference/environments/envs/cylc-rose.yml
@@ -2,6 +2,6 @@ name: cylc-rose
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|
   - cylc-rose
   - metomi-rose

--- a/src/reference/environments/envs/cylc-uiserver-with-traefik-proxy.yml
+++ b/src/reference/environments/envs/cylc-uiserver-with-traefik-proxy.yml
@@ -2,7 +2,7 @@ name: cylc-uiserver-with-traefik-proxy
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|
   - cylc-uiserver-hub-base
   - pip
   - pip:

--- a/src/reference/environments/envs/cylc-uiserver-without-jupyterhub.yml
+++ b/src/reference/environments/envs/cylc-uiserver-without-jupyterhub.yml
@@ -2,5 +2,5 @@ name: cylc-uiserver-without-jupyterhub
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|
   - cylc-uiserver-base

--- a/src/reference/environments/envs/cylc-uiserver.yml
+++ b/src/reference/environments/envs/cylc-uiserver.yml
@@ -2,5 +2,5 @@ name: cylc-uiserver
 channels:
   - conda-forge
 dependencies:
-  - cylc-flow =|release|
+  - cylc-flow =|version|
   - cylc-uiserver


### PR DESCRIPTION
Fix nightly builds and bring back `nightly.CCYY-MM-DD` version name in sidebar because it makes it more obvious you are looking at the nightly docs and we can more easily notice when the build is failing as the date becomes out-of-date.

- [x] Relies on releasing cylc-sphinx-extensions > 1.3.4