### PR TITLE
actions: fix create conda envs

### DIFF
--- a/.github/actions/create-conda-envs/action.yml
+++ b/.github/actions/create-conda-envs/action.yml
@@ -17,7 +17,7 @@ runs:
         # get cylc version...
         if [[ -z '${{ inputs.cylc_flow_version }}' ]]; then
           # ... from cylc library
-          CYLC_RELEASE="$(python ./docs/src/lib/cylc_release.py)"
+          CYLC_RELEASE="$(python ./src/lib/cylc_release.py)"
         else
           # ... from GitHub action input
           CYLC_RELEASE="${{ inputs.cylc_flow_version }}"


### PR DESCRIPTION
Action will still fail, but now for a valid reason, 8.0rc2 isn't out yet.

This will block the cylc-doc deployment, however, there is a flag in the action to ignore this step so this isn't a true blocker to 8.0rc2 cylc-doc release.

(we can still run the workflow against 8.0rc1 etc by manually triggering it)