### PR TITLE
migration gude: python 2 => 3 implications

### DIFF
--- a/src/7-to-8/major-changes/python-2-3.rst
+++ b/src/7-to-8/major-changes/python-2-3.rst
@@ -53,16 +53,16 @@ The following scripts must be upgraded if used:
    Any custom x-trigger functions.
 
 
-Module Changes
---------------
+Package Name Changes
+--------------------
 
-Three Python modules have been renamed between Cylc 7 and Cylc 8:
+Three Python packages have been renamed between Cylc 7 and Cylc 8:
 
 * ``cylc`` => ``cylc.flow``
 * ``isodatetime`` => ``metomi.isodatetime``
 * ``rose`` => ``metomi.rose``
 
-If you are importing these modules you will need to update the module names.
+If you are importing from these packages you will need to update the package names.
 
 Here are some examples:
 
@@ -75,7 +75,7 @@ Here are some examples:
    - from isodatetime.data import Duration
    + from metomi.isodatetime.data import Duration
 
-.. rubric:: Pyhton code which supports both Cylc 7 & Cylc 8:
+.. rubric:: Python code which supports both Cylc 7 & Cylc 8:
 
 .. code-block:: python
 

--- a/src/7-to-8/major-changes/python-2-3.rst
+++ b/src/7-to-8/major-changes/python-2-3.rst
@@ -14,7 +14,7 @@ Python 2 => 3
 Overview
 --------
 
-.. _six: src/7-to-8/major-changes/python-2-3.py
+.. _six: https://pypi.org/project/six/
 
 Cylc 7 ran under Python 2, Cylc 8 runs under Python 3.
 

--- a/src/7-to-8/major-changes/python-2-3.rst
+++ b/src/7-to-8/major-changes/python-2-3.rst
@@ -1,0 +1,120 @@
+Python 2 => 3
+=============
+
+.. admonition:: Does This Change Affect Me?
+   :class: tip
+
+   This change will affect you if your workflows extend Cylc or Jinja2 with
+   custom Python scripts.
+
+   This does not impact :term:`task` scripts, Cylc can still run Python 2
+   tasks if desired.
+
+
+Overview
+--------
+
+.. _six: src/7-to-8/major-changes/python-2-3.py
+
+Cylc 7 ran under Python 2, Cylc 8 runs under Python 3.
+
+Cylc can be extended with custom Python scripts. These scripts are run under
+the same version of Python used by Cylc.
+
+As a result if you are moving from Cylc 7 to Cylc 8 you must upgrade any
+scripts from Python 2 to Python 3 in the process.
+
+If you want to support both Cylc 7 and 8 you must support both Python 2 and 3.
+There are tools to help you do this e.g. `six`_.
+
+
+Impacted Scripts
+----------------
+
+The following scripts must be upgraded if used:
+
+:ref:`CustomJinja2Filters`
+   These allow you to extend Jinja2 with Python code.
+
+   These scripts are located in the following directories within a workflow:
+
+   * Jinja2Filters
+   * Jinja2Tests
+   * Jinja2Globals
+
+:ref:`Modules imported by Jinja2 <jinja2.importing_python_modules>`
+   Python modules can be imported from Jinja2 e.g:
+
+   .. code-block:: jinja
+
+      {% from "os" import path %}
+
+:ref:`Custom Trigger Functions`
+   Any custom x-trigger functions.
+
+
+Module Changes
+--------------
+
+Three Python modules have been renamed between Cylc 7 and Cylc 8:
+
+* ``cylc`` => ``cylc.flow``
+* ``isodatetime`` => ``metomi.isodatetime``
+* ``rose`` => ``metomi.rose``
+
+If you are importing these modules you will need to update the module names.
+
+Here are some examples:
+
+.. rubric:: Convert Python code from Cylc 7 to Cylc 8:
+
+.. code-block:: diff
+
+   - from cylc import LOG
+   + from cylc.flow import LOG
+   - from isodatetime.data import Duration
+   + from metomi.isodatetime.data import Duration
+
+.. rubric:: Pyhton code which supports both Cylc 7 & Cylc 8:
+
+.. code-block:: python
+
+   import sys
+   if sys.version[0] == '3':
+       from cylc.flow import LOG
+       from metomi.isodatetime.data import Duration
+   else:
+       from cylc import LOG
+       from isodatetime.data import Duration
+
+.. rubric:: Convert Jinja2 code from Cylc 7 to Cylc 8:
+
+.. code-block:: diff
+
+   #!Jinja2
+   - {% from "cylc" import LOG %}
+   + {% from "cylc.flow" import LOG %}
+     {% do LOG.debug("Hello World!") %}
+
+.. rubric:: Jinja2 code which supports both Cylc 7 & Cylc 8:
+
+.. code-block:: jinja
+
+   #!Jinja2
+   {% from "sys" import version -%}
+   {% if version[0] == '3' -%}
+       {% from "cylc.flow" import LOG -%}
+   {% else -%}
+       {% from "cylc" import LOG -%}
+   {% endif -%}
+   
+   {% do LOG.debug("Hello World!") %}
+
+
+Rose
+----
+
+The same changes also impact Rose extensions:
+
+* :ref:`Rose Macros <rose:api-rose-macro>`
+* :ref:`Rose Ana Tasks <rose:builtin.rose_ana>`

--- a/src/7-to-8/major-changes/python-2-3.rst
+++ b/src/7-to-8/major-changes/python-2-3.rst
@@ -25,7 +25,7 @@ As a result if you are moving from Cylc 7 to Cylc 8 you must upgrade any
 scripts from Python 2 to Python 3 in the process.
 
 If you want to support both Cylc 7 and 8 you must support both Python 2 and 3.
-There are tools to help you do this e.g. `six`_.
+There are tools to help you do this. E.g. `six`_.
 
 
 Impacted Scripts

--- a/src/conf.py
+++ b/src/conf.py
@@ -103,7 +103,7 @@ autosummary_imported_members = False
 # Mapping to other Sphinx projects we want to import references from.
 intersphinx_mapping = {
     'rose': (
-        'http://metomi.github.io/rose/doc/html', None
+        'http://metomi.github.io/rose/2.0rc2/html', None
     ),
     'python': (
         'https://docs.python.org/', None

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -425,7 +425,9 @@ Glossary
          * :term:`integer cycling`
          * :ref:`Cylc tutorial <tutorial-datetime-cycling>`
 
+   .. TODO - remove wall-clock definition
 
+   wall-clock time
    wallclock time
       The actual time (in the real world).
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1076,7 +1076,7 @@ Glossary
          * :term:`start`
          * :term:`restart`
          * :term:`reload`
-         * :ref:`Cylc User Guide <Stopping Suites>`
+         * :ref:`Tutorial <tutorial.start_stop_restart>`.
 
 
    restart
@@ -1096,7 +1096,7 @@ Glossary
          * :term:`start`
          * :term:`stop`
          * :term:`reload`
-         * :ref:`Cylc User Guide <Restarting Suites>`
+         * :ref:`Tutorial <tutorial.start_stop_restart>`.
 
 
    reload

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -177,6 +177,8 @@ Task jobs can fail for several reasons:
          submission retry delays = 2*PT10M, PT30M
 
 
+.. _tutorial.start_stop_restart:
+
 Start, Stop, Restart
 --------------------
 

--- a/src/user-guide/writing-workflows/jinja2.rst
+++ b/src/user-guide/writing-workflows/jinja2.rst
@@ -479,6 +479,8 @@ following example is equivalent to the "raise" example above.
    {{ assert(VARIABLE is defined, 'VARIABLE must be defined for this workflow.') }}
 
 
+.. _jinja2.importing_python_modules:
+
 Importing Python modules
 ------------------------
 


### PR DESCRIPTION
Add a major changes page covering Python changes which may need to be made during Cylc 7 -> 8 porting.

This is a list off the top of my head, can we think of anything else?