### PR TITLE
Reload triggers remote file installation documentation

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -162,8 +162,8 @@ By default, run numbers increment with each install.
 
 File Installation
 ^^^^^^^^^^^^^^^^^
-When the first job runs on a remote platform, a remote initialization process
-is triggered to install files onto platforms.
+When the first job runs on a remote platform (or after a ``cylc reload``), a
+remote initialization process is triggered to install files onto platforms.
 
 Symlink Dirs
 ^^^^^^^^^^^^

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -162,8 +162,8 @@ By default, run numbers increment with each install.
 
 File Installation
 ^^^^^^^^^^^^^^^^^
-When the first job runs on a remote platform (or after a ``cylc reload``), a
-remote initialization process is triggered to install files onto platforms.
+When the first job runs on a remote platform (after start-up, or after a ``cylc reload``), a
+remote initialization process is triggered to install workflow files there.
 
 Symlink Dirs
 ^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1108,8 +1108,7 @@ Glossary
       workflow :term:`source directory` before reload, rather than made by
       editing the installed files directly.
 
-      :ref:`RemoteInit` will be triggered upon reload. This will not take effect
-      for running tasks but for the job submission of subsequent tasks.
+      :ref:`RemoteInit` will be redone for each job platform, when the first job is submitted there after a reload.
 
       Any :term:`task` that is active at reload will continue with its
       pre-reload configuration. It's next instance (at the next cycle point)

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1108,6 +1108,9 @@ Glossary
       workflow :term:`source directory` before reload, rather than made by
       editing the installed files directly.
 
+      :ref:`RemoteInit` will be triggered upon reload. This will not take effect
+      for running tasks but for the job submission of subsequent tasks.
+
       Any :term:`task` that is active at reload will continue with its
       pre-reload configuration. It's next instance (at the next cycle point)
       will adopt the new configuration.

--- a/src/user-guide/running-workflows/scheduler-start-up.rst
+++ b/src/user-guide/running-workflows/scheduler-start-up.rst
@@ -137,6 +137,8 @@ workflow down and restarting it after making changes.
 If you make an error in the ``flow.cylc`` file before a reload, the workflow
 log will report an error and the reload will have no effect.
 
+Note, :ref:`RemoteInit` will be triggered upon reload. This will affect any
+subsequent tasks, and not currently running ones.
 
 Restarting or Reloading after Graph Changes
 -------------------------------------------
@@ -207,6 +209,10 @@ they don't slow the workflow start-up process, they can be monitored,
 they can run directly on target platforms, and you can rerun them later without
 restarting the workflow.
 
+.. note::
+
+   Any files configured to be included in the remote file installation that are
+   changed, can be reinstalled on the remote with ``cylc reload``.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^

--- a/src/user-guide/running-workflows/scheduler-start-up.rst
+++ b/src/user-guide/running-workflows/scheduler-start-up.rst
@@ -137,8 +137,8 @@ workflow down and restarting it after making changes.
 If you make an error in the ``flow.cylc`` file before a reload, the workflow
 log will report an error and the reload will have no effect.
 
-Note, :ref:`RemoteInit` will be triggered upon reload. This will affect any
-subsequent tasks, and not currently running ones.
+Note, :ref:`RemoteInit` will be redone for each job platform, when the first
+job is submitted there after a reload.
 
 Restarting or Reloading after Graph Changes
 -------------------------------------------

--- a/src/user-guide/running-workflows/scheduler-start-up.rst
+++ b/src/user-guide/running-workflows/scheduler-start-up.rst
@@ -211,8 +211,7 @@ restarting the workflow.
 
 .. note::
 
-   Any files configured to be included in the remote file installation that are
-   changed, can be reinstalled on the remote with ``cylc reload``.
+   Files configured for installation to remote job platforms can be reinstalled by doing a reload. The reinstallation is done when the first job submits to a platform after the reload.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Small documentation change to make it clear that file installation will be triggered upon `cylc reload`.
https://github.com/cylc/cylc-flow/pull/4797 (cylc -flow sibling)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
