### PR TITLE
728: remove warning

### DIFF
--- a/src/7-to-8/major-changes/remote-owner.rst
+++ b/src/7-to-8/major-changes/remote-owner.rst
@@ -34,15 +34,6 @@ remote machine.
 Since Cylc uses SSH and RSync to manage job hosts, the SSH config also configures
 Cylc.
 
-.. warning::
-
-   GNU/BSD RSync is usually configured to use SSH for its transport layer,
-   however, other options, namely RSH may also be available.
-
-   If using the SSH config to set your remote username ensure RSync is configured
-   to use the SSH transport layer, or that the chosen transport layer is itself
-   appropriately configured.
-
 .. note::
 
    This approach using the SSH configuration file also works with Cylc 7.


### PR DESCRIPTION
* SSH should be the default transport for modern Rsync implementations
  this is a little too historical to be of concern, hopefully.

(MB force-pushed over a review comment)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
