### PR TITLE
s/expected/required/g outputs.

### DIFF
--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -33,10 +33,10 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
   - (Cylc 8 spawns tasks on demand, and suicide triggers are not needed for
     branching)
 
-- only ``succeeded`` task outputs are :ref:`*expected* <User Guide Expected Outputs>`,
+- only ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
   meaning the scheduler will retain tasks that do not succeed as incomplete
 
-  - (in Cylc 8, **all** outputs are *expected* unless marked as
+  - (in Cylc 8, **all** outputs are *required* unless marked as
     :ref:`*optional* <User Guide Optional Outputs>` by the new ``?`` syntax)
 
 

--- a/src/7-to-8/major-changes/scheduling.rst
+++ b/src/7-to-8/major-changes/scheduling.rst
@@ -11,7 +11,7 @@ Scheduling Algorithm
 
    User Guide:
 
-   * :ref:`User Guide Expected Outputs`
+   * :ref:`User Guide Required Outputs`
    * :ref:`User Guide Optional Outputs`
    * :ref:`user-guide-reflow`
    * :ref:`n-window`
@@ -29,7 +29,7 @@ Cylc 8 has a new scheduling algorithm that:
   - succeeded tasks are not kept across the active task window
   - no costly indiscriminate dependency matching is done
 - Distinguishes between :term:`optional <optional output>` and
-  :term:`expected <expected output>` task outputs, to support:
+  :term:`required <required output>` task outputs, to support:
 
   - :term:`graph branching` without :term:`suicide triggers <suicide trigger>`
   - correct diagnosis of :term:`workflow completion`

--- a/src/7-to-8/major-changes/suicide-triggers.rst
+++ b/src/7-to-8/major-changes/suicide-triggers.rst
@@ -70,7 +70,7 @@ Validating this with Cylc 8 will give an error:
    $ cylc validate .
    GraphParseError: Opposite outputs foo:succeeded and foo:failed must both be optional if both are used
 
-In Cylc 8, all task outputs are :term:`expected <expected output>` to complete
+In Cylc 8, all task outputs are :term:`required <required output>` to complete
 unless otherwise indicated. However, it is impossible for both ``:succeed``
 and ``:fail`` to occur when a task runs.
 

--- a/src/7-to-8/major-changes/suicide-triggers.rst
+++ b/src/7-to-8/major-changes/suicide-triggers.rst
@@ -104,7 +104,7 @@ likely unnecessary.)
 
 .. seealso::
 
-   - :ref:`Expected <User Guide Expected Outputs>` and
-     :ref:`optional <User Guide Optional outputs>` outputs in the user guide.
+   - :ref:`Required <User Guide Required Outputs>` and
+     :ref:`optional <User Guide Optional Outputs>` outputs in the User Guide.
 
    - :ref:`Graph Branching` in the user guide.

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -106,17 +106,17 @@ separated and states of both can be viewed in the GUI.
 For more information, see :ref:`728.task_job_states`.
 
 
-Optional and Expected Task Outputs
+Optional and Required Task Outputs
 ----------------------------------
 
 .. seealso::
 
    * Major Changes::ref:`728.optional_outputs`
-   * User Guide::ref:`User Guide Expected Outputs`
+   * User Guide::ref:`User Guide Required Outputs`
    * User Guide::ref:`User Guide Optional Outputs`
 
-By default, all Cylc 8 tasks are expected to succeed - i.e., success is
-an :term:`expected output <expected output>`. Otherwise they will be marked
+By default, all Cylc 8 tasks are required to succeed - i.e., success is
+a :term:`required output`. Otherwise they will be marked
 as :term:`incomplete tasks<incomplete task>` requiring user intervention.
 In a workflow with incomplete tasks, if there is nothing left to do, the
 scheduler will :term:`stall` rather than shut down.

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -117,7 +117,7 @@ Optional and Required Task Outputs
 
 By default, all Cylc 8 tasks are required to succeed - i.e., success is
 a :term:`required output`. Otherwise they will be marked
-as :term:`incomplete tasks<incomplete task>` requiring user intervention.
+as :term:`incomplete tasks<incomplete task>` needing user intervention.
 In a workflow with incomplete tasks, if there is nothing left to do, the
 scheduler will :term:`stall` rather than shut down.
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1335,7 +1335,7 @@ Glossary
       determined by the :term:`graph`.
 
       Outputs are written as ``task-name:output`` in the :term:`graph`, and can
-      be :term:`expected <expected output>` or :term:`optional <optional output>`.
+      be :term:`required <required output>` or :term:`optional <optional output>`.
 
       Tasks may have :term:`custom outputs <custom output>` as well as
       :term:`standard outputs <standard output>`.
@@ -1476,25 +1476,25 @@ Glossary
 
       .. seealso::
 
-         * :term:`expected output`
+         * :term:`required output`
          * :ref:`Cylc User Guide <User Guide Optional Outputs>`
 
 
-   expected output
+   required output
       Task outputs that are not marked as :term:`optional <optional output>`
-      in the :term:`graph` are expected to be completed at runtime. If not, the
+      in the :term:`graph` are required to be completed at runtime. If not, the
       :term:`scheduler` retains the task as :term:`incomplete` pending user
       intervention.
 
       .. seealso::
 
-         * :ref:`Cylc User Guide <expected outputs>`
+         * :ref:`Cylc User Guide <required outputs>`
 
 
    incomplete
    incomplete task
       Incomplete tasks are :term:`tasks <task>` that finish (succeed or fail)
-      without completing all :term:`expected outputs <expected output>`. They
+      without completing all :term:`required outputs <required output>`. They
       are retained by the :term:`scheduler` in the :term:`n=0 window
       <n-window>` pending user intervention, and will cause a :term:`stall`
       if there are no more tasks to run.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1481,6 +1481,7 @@ Glossary
 
 
    required output
+   expected output
       Task outputs that are not marked as :term:`optional <optional output>`
       in the :term:`graph` are required to be completed at runtime. If not, the
       :term:`scheduler` retains the task as :term:`incomplete` pending user

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -137,13 +137,13 @@ Merging with Incomplete tasks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :term:`Incomplete<incomplete>` tasks are retained in the active window in
-expectation of retriggering to complete :term:`expected outputs<expected
+expectation of retriggering to complete :term:`required outputs<required
 output>` and continue their flow.
 
 If another flow encounters an incomplete task (i.e. if another instance of the
 same task collides with it in the ``n=0`` :term:`active window`) the task will
 run again and carry both flow numbers forward if it successfully completes its
-expected outputs.
+required outputs.
 
 
 Stopping Flows

--- a/src/user-guide/running-workflows/tasks-jobs-ui.rst
+++ b/src/user-guide/running-workflows/tasks-jobs-ui.rst
@@ -26,8 +26,8 @@ The ``n = 0`` or *active task* window includes:
 
   - ``submit-failed`` tasks, if successful submission was not :term:`optional
     <optional output>`
-  - ``succeeded`` or ``failed`` tasks that did not complete :term:`expected
-    outputs <expected output>`
+  - ``succeeded`` or ``failed`` tasks that did not complete :term:`required
+    outputs <required output>`
 
 The default window extent is ``n = 1``, i.e. tasks out to one graph edge from
 current active tasks.

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -19,8 +19,8 @@ If there is nothing more to run (according to the graph) but there are
 to allow the workflow to continue.
 
 The presence of incomplete tasks means that the workflow did not run to
-completion as expected, because some :term:`expected task outputs
-<expected output>` were not completed at runtime.
+completion as expected, because some :term:`required task outputs
+<required output>` were not completed at runtime.
 
 Restarting a stalled workflow triggers a new stall timer.
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1520,24 +1520,24 @@ in :ref:`Section External Triggers`.
 
 
 
-.. _User Guide Expected Outputs:
-.. _expected outputs:
+.. _User Guide Required Outputs:
+.. _required outputs:
 .. _incomplete tasks:
 
-Expected Outputs
+Required Outputs
 ----------------
 
 .. versionadded:: 8.0.0
 
 :term:`Task outputs <task output>` in the :term:`graph` are either
-:term:`expected <expected output>` (the default) or  :term:`optional <optional
+:term:`required <required output>` (the default) or  :term:`optional <optional
 output>`.
 
 The scheduler expects all task outputs to be completed at runtime, unless they
 are marked with ``?`` as optional. This allows it to correctly diagnose
 :term:`workflow completion`. [2]_
 
-Tasks that finish without completing expected outputs  [3]_ are retained as
+Tasks that finish without completing required outputs  [3]_ are retained as
 :ref:`incomplete <incomplete tasks>` pending user intervention, e.g. to be
 retriggered after a bug fix.
 
@@ -1554,11 +1554,11 @@ This graph says task ``bar`` should trigger if ``foo`` succeeds:
 
    foo => bar  # short for "foo:succeed => bar"
 
-Additionally, ``foo`` is expected to succeed, because its success is not marked
+Additionally, ``foo`` is required to succeed, because its success is not marked
 as optional. If ``foo`` does not succeeded, the scheduler will not run ``bar``,
 and ``foo`` will be retained as an incomplete task.
 
-Here, ``foo:succeed``, ``bar:x``, and ``baz:fail`` are all expected outputs:
+Here, ``foo:succeed``, ``bar:x``, and ``baz:fail`` are all required outputs:
 
 .. code-block:: cylc-graph
 
@@ -1566,17 +1566,17 @@ Here, ``foo:succeed``, ``bar:x``, and ``baz:fail`` are all expected outputs:
    bar:x
    baz:fail
 
-Tasks that appear with only custom outputs in the graph are also expected to succeed.
-Here, ``foo:succeed`` is an expected output, as well as ``foo:x``, unless it is
+Tasks that appear with only custom outputs in the graph are also required to succeed.
+Here, ``foo:succeed`` is a required output, as well as ``foo:x``, unless it is
 marked as optional elsewhere in the graph:
 
 .. code-block:: cylc-graph
 
    foo:x => bar
 
-If a task generates multiple custom outputs, they should be "expected" if you
+If a task generates multiple custom outputs, they should be "required" if you
 expect them all to be completed every time the task runs. Here,
-``model:file1``, ``model:file2``, and ``model:file3`` are all expected outputs:
+``model:file1``, ``model:file2``, and ``model:file3`` are all required outputs:
 
 .. code-block:: cylc-graph
 
@@ -1645,7 +1645,7 @@ particular branch is taken or not depends on which optional outputs are
 completed at runtime. For more information see :ref:`Graph Branching`.
 
 Leaf tasks (with nothing downstream of them) can have optional outputs. In the
-following graph, ``foo`` is expected to succeed, but it doesn't matter whether
+following graph, ``foo`` is required to succeed, but it doesn't matter whether
 ``bar`` succeeds or fails:
 
 .. code-block:: cylc-graph
@@ -1680,7 +1680,7 @@ Finish Triggers
 
 ``foo:finish`` is a pseudo output that is short for ``foo:succeed? |
 foo:fail?``. This automatically labels the real outputs as optional, because
-success and failure can't both be expected.
+success and failure can't both be required.
 
 ``foo:finish?`` is illegal because it incorrectly suggests that "finishing
 is optional" and that a non-optional version of the trigger makes sense.
@@ -1711,7 +1711,7 @@ and ``FAM:fail-any`` that are short for logical expressions involving the
 corresponding member task outputs.
 
 If the member outputs are not singled out explicitly elsewhere in the graph,
-then they default to being expected outputs.
+then they default to being required outputs.
 
 For example, if ``f1`` and ``f2`` are members of ``FAM``, then this:
 
@@ -1724,7 +1724,7 @@ means:
 
 .. code-block:: cylc-graph
 
-   f1:fail & f2:fail => a  # f1:fail and f2:fail are expected
+   f1:fail & f2:fail => a  # f1:fail and f2:fail are required
 
 
 and this:
@@ -1738,7 +1738,7 @@ means:
 
 .. code-block:: cylc-graph
 
-   f1 | f2 => a  # f1:succeed and f2:succeed are expected
+   f1 | f2 => a  # f1:succeed and f2:succeed are required
 
 
 However, the family default can be changed to optional by using ``?`` on the
@@ -1757,11 +1757,11 @@ means this:
 
 
 If particular member tasks are singled out elsewhere in the graph, that
-overrides the family default for expected/optional outputs:
+overrides the family default for required/optional outputs:
 
 .. code-block:: cylc-graph
 
-   # f1:fail is expected, and f2:fail is optional:
+   # f1:fail is required, and f2:fail is optional:
    FAM:fail-all => a
    f2:fail? => b
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1533,7 +1533,7 @@ Required Outputs
 :term:`required <required output>` (the default) or  :term:`optional <optional
 output>`.
 
-The scheduler expects all task outputs to be completed at runtime, unless they
+The scheduler requires all task outputs to be completed at runtime, unless they
 are marked with ``?`` as optional. This allows it to correctly diagnose
 :term:`workflow completion`. [2]_
 


### PR DESCRIPTION
Terminology consistency tweak. (As discussed offline)

(Some extant doc PRs might need tweaking in the same way, now or post merge).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
