### PR TITLE
Document how to continue a Cylc 7 run with Cylc 8.

### DIFF
--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -91,9 +91,9 @@ interoperability if your workflows extend Cylc or Jinja2 with custom Python scri
 Other caveats
 ^^^^^^^^^^^^^
 
-- Cylc 8 cannot *restart* a Cylc 7 workflow mid-run. If you need to run an
-  already-started Cylc 7 workflow to completion, we recommend still using
-  Cylc 7 to do so.
+- Cylc 8 cannot *restart* a partially completed Cylc 7 workflow in-place. If
+  possible, complete the run with Cylc 7. Otherwise, see
+  :ref:`compat_continuing_c7_with_c8`.
 
 - Cylc 8 only transfers certain files and directories by default during
   remote installation. See :ref:`728.remote-install` for more information.

--- a/src/7-to-8/major-changes/continuing-c7-c8.rst
+++ b/src/7-to-8/major-changes/continuing-c7-c8.rst
@@ -8,8 +8,8 @@ Continuing a Cylc 7 Workflow with Cylc 8
 
    Read this if you have a partially complete Cylc 7 workflow that you want to
    continue, rather than start from scratch, with Cylc 8. Some cycling
-   workflows, for example, may need to run expensive "cold start" tasks
-   and incur a multi-cycle spin-up if started from scratch.
+   workflows, for example, may need to run expensive "cold start" tasks and
+   incur a multi-cycle spin-up if started from scratch.
 
 .. warning::
 
@@ -35,7 +35,12 @@ To continue a Cylc 7 workflow with Cylc 8:
 
    - This could include external files installed by initial tasks at runtime
    - Note different files could be present on different job platforms
-4. Start the new Cylc 8 run at the appropriate cycle point or task(s)
+4. Start the new Cylc 8 run at the appropriate cycle point or task(s) in the
+   graph
 
-   - To avoid re-running initial tasks, don't reset the :term:`initial
-     cycle point` to the new :term:`start point <start cycle point>`
+   - Don't reset the :term:`initial cycle point` (in the ``flow.cylc`` or on
+     the command line) to the :term:`start point <start cycle point>` of the
+     Cylc 8 run. That would result in the "cold start" that this continuation
+     procedure is designed to avoid. Instead use the ``--start-cycle-point``
+     option (or ``--start-task``) with ``cylc play``, to start at the right
+     place within the graph.

--- a/src/7-to-8/major-changes/continuing-c7-c8.rst
+++ b/src/7-to-8/major-changes/continuing-c7-c8.rst
@@ -1,0 +1,41 @@
+.. _compat_continuing_c7_with_c8:
+
+Continuing a Cylc 7 Workflow with Cylc 8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. admonition:: Does This Change Affect Me?
+   :class: tip
+
+   Read this if you have a partially complete Cylc 7 workflow that you want to
+   continue, rather than start from scratch, with Cylc 8. Some cycling
+   workflows, for example, may need to run expensive "cold start" tasks
+   and incur a multi-cycle spin-up if started from scratch.
+
+.. warning::
+
+   Cylc 8 cannot restart a Cylc 7 workflow in-place, and continuing in a new
+   run directory involves some careful set up (below). So, **if possible you
+   should complete the run with Cylc 7**.
+
+
+To continue a Cylc 7 workflow with Cylc 8:
+
+1. Stop the Cylc 7 workflow at an convenient place
+
+   - Typically the end of a cycle point, to simplify the continuation
+2. :ref:`Install <MajorChangesInstall>` a new instance of the workflow from
+   source, with Cylc 8
+
+   - Adapt file paths to the new run directory structure, in workflow and task
+     configurations
+   - Note Cylc 8 does :ref:`remote file installation <728.remote-install>`
+     when a job is first submitted to a platform
+3. Copy runtime files needed by upcoming tasks from the old to the new run
+   directory
+
+   - This could include external files installed by initial tasks at runtime
+   - Note different files could be present on different job platforms
+4. Start the new Cylc 8 run at the appropriate cycle point or task(s)
+
+   - To avoid re-running initial tasks, don't reset the :term:`initial
+     cycle point` to the new :term:`start point <start cycle point>`


### PR DESCRIPTION
Follow-up https://github.com/cylc/cylc-doc/pull/490#discussion_r922915976 

Many Cylc 7 workflows (at NIWA anyway!) "warm cycle" indefinitely, and cold-starting them is a last resort. 

E.g. our warm-cycled limited area atmos workflows can be cold started from global model data if absolutely necessary, but then forecast quality suffers over a subsequent spin-up period. 

Consequently, we can't just say "complete your run with Cylc 7". The best we can do is warn that that's preferred option *if possible*, and explain how to continue a run with Cylc 8, in a new run directory, if needed.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
