### PR TITLE
small change to make usage of cylc get-resources consistent.

### DIFF
--- a/src/tutorial/runtime/introduction.rst
+++ b/src/tutorial/runtime/introduction.rst
@@ -478,7 +478,7 @@ Files Generated at Runtime
       .. code-block:: bash
 
          cylc get-resources tutorial/runtime-introduction
-         cd ~/cylc-src/tutorial/runtime-introduction
+         cd ~/cylc-src/runtime-introduction
 
       This includes the :cylc:conf:`flow.cylc` file from the
       :ref:`weather forecasting workflow <tutorial-datetime-cycling-practical>`

--- a/src/tutorial/runtime/introduction.rst
+++ b/src/tutorial/runtime/introduction.rst
@@ -477,7 +477,7 @@ Files Generated at Runtime
 
       .. code-block:: bash
 
-         cylc get-resources tutorial
+         cylc get-resources tutorial/runtime-introduction
          cd ~/cylc-src/tutorial/runtime-introduction
 
       This includes the :cylc:conf:`flow.cylc` file from the


### PR DESCRIPTION
Ensure consistency of use of `cylc get-resource` across tutorials.

Partially addresses https://github.com/cylc/cylc-doc/issues/470
Twinned with: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
