### PR TITLE
make: fix watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ watch: clean
 		--ignore='**plugins/main-loop/built-in/*.rst' \
 		--ignore='**plugins/install/built-in/*.rst' \
 		--ignore='**/job-runner-handlers/*.rst' \
+		--ignore='**/dictionaries/**' \
 		--open-browser
 
 watch-cylc:
@@ -39,6 +40,7 @@ watch-cylc:
 		--ignore='**plugins/main-loop/built-in/*.rst' \
 		--ignore='**plugins/install/built-in/*.rst' \
 		--ignore='**/job-runner-handlers/*.rst' \
+		--ignore='**/dictionaries/**' \
 		--watch="$(shell bin/c-locate cylc.flow)" \
 		--watch="$(shell bin/c-locate cylc.uiserver)" \
 		--watch="$(shell bin/c-locate cylc.rose)" \


### PR DESCRIPTION
* The `watch` builds were getting stuck in an infinite rebuild loop due
  to changes in the dictionary directory at build time.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
