### PR TITLE
Bump min python to 3.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'dependencies'
+      - 'infrastructure'

--- a/.github/workflows/create-conda-envs.yml
+++ b/.github/workflows/create-conda-envs.yml
@@ -26,9 +26,9 @@ jobs:
       - name: configure python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
-      - name: install
+      - name: install setuptools
         run: |
           # pick up deps for version processing
           pip install 'setuptools>=50'

--- a/.github/workflows/create-conda-envs.yml
+++ b/.github/workflows/create-conda-envs.yml
@@ -12,6 +12,10 @@ on:
         description: 'Version to install.'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_conda_install:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: configure python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: checkout cylc-doc
         uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
         uses: ./docs/.github/actions/create-conda-envs
         if: ${{ ! inputs.skip_conda_environment_check }}
         with:
-          python_version: '3.7'
+          python_version: '3.9'
           working_directory: ./docs
 
       - name: checkout gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,9 @@ on:
         default: false
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
       - name: configure python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: checkout cylc-doc
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,9 @@ on:
   schedule:
     - cron: '35 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ on:
         description: 'metomi-rose ref (for cylc-rose install)'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: configure python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: configure node
         uses: actions/setup-node@v2

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -28,6 +28,9 @@ on:
         description: 'Tag present on both cylc-flow and cylc-docs.'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   undeploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: configure python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: checkout cylc-doc
         uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ packages = find_namespace:
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    cylc-sphinx-extensions>=1.3.5
+    cylc-sphinx-extensions>=1.4.1
     eralchemy==1.2.*
     hieroglyph>=2.1.0
     setuptools>=50
@@ -62,14 +62,14 @@ include = cylc*
 
 [options.extras_require]
 test =
-    flake8
-    flake8-broken-line>=0.3.0
-    flake8-bugbear>=21.0.0
+    flake8>=5.0
+    flake8-broken-line>=0.5.0
+    flake8-bugbear>=22.7.0
     flake8-builtins>=1.5.0
-    flake8-comprehensions>=3.5.0
-    flake8-debugger>=4.0.0
+    flake8-comprehensions>=3.10.0
+    flake8-debugger>=4.1.0
     flake8-mutable>=1.2.0
-    flake8-simplify>=0.14.0
+    flake8-simplify>=0.19.0
 watch =
     sphinx-autobuild
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
@@ -46,7 +45,7 @@ classifiers =
 [options]
 packages = find_namespace:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     cylc-sphinx-extensions>=1.4.1
     eralchemy==1.2.*


### PR DESCRIPTION
These changes fix pip dependency resolution timing out on GH Actions (caused by https://github.com/PyCQA/flake8/commit/975a3f45334861ebd8960c00e881443c23654bca)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
