### PR TITLE
7-to-8: Note config setting shorthand in validation warnings.

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -46,6 +46,11 @@ take action on any warnings.
 .. TODO Add ref to breaking changes section within Major changes, once created,
    including optional ouputs.
 
+.. note::
+
+   Validation warnings use a :ref:`shorthand notation<config_item_shorthand>`
+   to refer to nested configuration settings on a single line, like this:
+   ``[section][sub-section]item``.
 
 
 New Web and Terminal UIs

--- a/src/reference/config/file-format.rst
+++ b/src/reference/config/file-format.rst
@@ -158,23 +158,19 @@ Include-files
    :ref:`Jinja2's <Jinja>` template inclusion mechanism can be used with Cylc
    too.
 
+.. _config_item_shorthand:
 
 Shorthand
 ---------
 
-Throughout the documentation we refer to configuration settings in the
-following way:
+.. include:: shorthand.rst
 
-``[section]``
-   An entire section.
-``[section]setting``
-   A setting within a section.
-``[section]setting=value``
-   The value of a setting within a section.
-``[section][sub-section]another-setting``
-   A setting within a sub-section.
+.. code-block:: cylc
 
-.. warning::
-   We only use one set of square brackets at each level when writing nested
-   sections on one line like this. But in the file, each sub-section
-   gets additional square brackets as shown above.
+   # This:
+   #   [runtime][task-a][environment]FOO = foo
+   # Means:
+   [runtime]
+       [[task-a]]
+           [[[environment]]]
+               FOO = foo

--- a/src/reference/config/shorthand.rst
+++ b/src/reference/config/shorthand.rst
@@ -1,0 +1,12 @@
+We often use a compact single-line notation to refer to nested config items:
+
+``[section]``
+   An entire section.
+``[section]setting``
+   A setting within a section.
+``[section]setting=value``
+   The value of a setting within a section.
+``[section][sub-section]another-setting``
+   A setting within a sub-section.
+
+In the file, however, section headings need additional brackets at each level.

--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -58,18 +58,7 @@ Example
 Shorthand
 ^^^^^^^^^
 
-Throughout this tutorial we will refer to configuration settings in the following ways:
-
-``[section]``
-   An entire section.
-``[section]key``
-   A specific config item, within a section.
-``[section]key=value``
-   The value of a specific config item, within a section.
-``[section][sub-section]another-key``
-   Note we only use one set of square brackets per section heading when
-   writing on one line like this. In the config file each nested level
-   gets another set of square brackets.
+.. include:: ../../reference/config/shorthand.rst
 
 Duplicate Items
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
A user has complained thusly:

> This [upgrading to Cylc 8] isn’t as straightforward as it should be as: the WARNING message is written in a confusing shorthand; the ‘migration to cylc 8’ guide hasn’t told me where to find the document I need to understand the shorthand.

The shorthand referred to is:
```ini
[a cat]
    [[a dog]]
         [[[a fish]]]
```
gets written on one line as:
```ini
[a cat][a dog][a fish]
```

This PR adds a link from the migration guide to the file format documentation, and extends the documentation a bit.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
