### PR TITLE
Remove 8.0a2 from `versions.json`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,10 +3,6 @@
         "slides",
         "html"
     ],
-    "8.0a2": [
-        "slides",
-        "html"
-    ],
     "8.0rc2": [
         "slides",
         "html"


### PR DESCRIPTION
This removes 8.0a2 from the sidebar (as the link is now dead).

The undeploy GH workflow didn't do this, I will try to fix that separately.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
