### PR TITLE
Fix `undeploy` workflow's `versions.json` cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,17 +65,21 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: configure git
+        uses: cylc/release-actions/configure-git@v1
+
       - name: checkout cylc-doc
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.cylc-flow-tag }}
+          ref: ${{ inputs.cylc-flow-tag }}
           path: docs
 
       - name: install dependencies
         uses: cylc/cylc-doc/.github/actions/install-dependencies@master
 
       - name: install cylc-doc
-        run: pip install "${{ github.workspace }}/docs[all]"
+        working-directory: docs
+        run: pip install ".[all]"
 
       - name: install libs to document
         uses: cylc/cylc-doc/.github/actions/install-libs@master
@@ -94,21 +98,18 @@ jobs:
           path: gh-pages
 
       - name: sync static files
-        if: ${{ github.event.inputs.set_stable == 'true' }}
+        if: ${{ inputs.set_stable }}
+        env:
+          DOCS: '${{ github.workspace }}/docs'
+          PAGE: '${{ github.workspace }}/gh-pages'
         run: |
-          DOCS="${{ github.workspace }}/docs" \
-          PAGE="${{ github.workspace }}/gh-pages"  \
-
           rsync -r "$DOCS/doc/" "$PAGE/"
 
       - name: install gh-pages
+        working-directory: docs
         run: |
-          DOCS="${{ github.workspace }}/docs" \
-          PAGE="${{ github.workspace }}/gh-pages"  \
-
-          cd "$DOCS"
           rm -r doc
-          ln -s "$PAGE" doc
+          ln -s ../gh-pages doc
 
       - name: build docs
         run: |
@@ -120,20 +121,17 @@ jobs:
             slides \
             linkcheck \
             SPHINXOPTS='-Wn' \
-            STABLE=${{ github.event.inputs.set_stable }} \
-            LATEST=${{ github.event.inputs.set_latest }}
-
-      - name: configure git
-        uses: cylc/release-actions/configure-git@v1
+            STABLE=${{ inputs.set_stable }} \
+            LATEST=${{ inputs.set_latest }}
 
       - name: tidy old versions
+        working-directory: docs
         run: |
-          cd docs
-          git rm -r $("${{ github.workspace }}/docs/bin/version" tidy) || true
+          git rm -r $("./bin/version" tidy) || true
 
       - name: push changes
+        working-directory: gh-pages
         run: |
-          cd gh-pages
           git add *
-          git commit -m "add: ${{ github.event.inputs.cylc-flow-tag }}"
+          git commit -m "add: ${{ inputs.cylc-flow-tag }}"
           git push origin HEAD

--- a/.github/workflows/shortlog.yml
+++ b/.github/workflows/shortlog.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/shortlog.yml'
 
 jobs:
-  test:
+  shortlog:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     steps:

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     env:
-      TAG: ${{ github.event.inputs.tag }}
+      TAG: ${{ inputs.tag }}
     steps:
       - name: configure python
         uses: actions/setup-python@v4

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -43,8 +43,13 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: configure git
+        uses: cylc/release-actions/configure-git@v1
+
       - name: checkout cylc-doc
         uses: actions/checkout@v3
+        with:
+          path: docs
 
       - name: checkout gh-pages
         uses: actions/checkout@v3
@@ -67,8 +72,11 @@ jobs:
             fi
           done
 
-      - name: configure git
-        uses: cylc/release-actions/configure-git@v1
+      - name: install gh-pages
+        working-directory: docs
+        run: |
+          rm -r doc
+          ln -s ../gh-pages doc
 
       - name: remove version
         working-directory: gh-pages
@@ -76,8 +84,9 @@ jobs:
           git rm -r "$TAG"
 
       - name: update version file
+        working-directory: docs
         run: |
-          bin/version write
+          bin/version write > doc/versions.json
 
       - name: push changes
         working-directory: gh-pages


### PR DESCRIPTION
The GH Actions `undeploy` workflow was failing to remove the version from `versions.json` (and hence the docs sidebar). This PR fixes that and tidies the GH Actions workflows a little.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
