### PR TITLE
GH Actions: upgrade to `ubuntu-latest`; use conda to install graphviz

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,5 +1,5 @@
 name: Install dependencies
-description: apt-get dependencies
+description: Install dependencies and setup + activate conda env
 
 runs:
   using: composite
@@ -15,7 +15,6 @@ runs:
         sudo apt-get install -y \
           librsvg2-bin \
           ghostscript \
-          graphviz \
           pkg-config \
           libgraphviz-dev \
           gsfonts \
@@ -23,3 +22,15 @@ runs:
           libfontconfig1-dev
       # Explanation of some of these dependencies:
       # https://github.com/ImageMagick/ImageMagick/issues/374#issuecomment-279252866
+
+    - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169 # v2.1.1
+      with:
+        channels: conda-forge
+        python-version: ${{ matrix.python-version || '' }}
+        miniforge-version: latest
+
+    # use login shell for conda activation
+    - shell: bash -leo pipefail {0}
+      run: |
+        echo "CONDA_PREFIX: ${CONDA_PREFIX}"
+        conda install -y graphviz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,8 +57,12 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
+    defaults:
+      run:
+        # use login shell for conda activation
+        shell: bash -leo pipefail {0}
     steps:
       - name: configure python
         uses: actions/setup-python@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,8 +31,12 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        # use login shell for conda activation
+        shell: bash -leo pipefail {0}
     steps:
       - name: configure python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,12 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        # use login shell for conda activation
+        shell: bash -leo pipefail {0}
     steps:
       - name: configure python
         uses: actions/setup-python@v4

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag present on both cylc-flow and cylc-docs.'
+        description: 'Tag present on both cylc-flow and cylc-doc'
         required: true
 
 concurrency:
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   undeploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       TAG: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
`ubuntu-18.04` is now deprecated - https://github.com/actions/runner-images/issues/6002

Closes #247

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
