### PR TITLE
Fix spellcheck on GH Actions

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -9,6 +9,9 @@ runs:
         echo "[command]sudo apt-get update"
         sudo apt-get update
 
+    # Explanation of these dependencies:
+    # - https://github.com/ImageMagick/ImageMagick/issues/374#issuecomment-279252866
+    # - aspell-en for spellchecking
     - shell: bash
       run: |
         echo "[command]sudo apt-get install -y ..."
@@ -19,9 +22,8 @@ runs:
           libgraphviz-dev \
           gsfonts \
           libfreetype6-dev \
-          libfontconfig1-dev
-      # Explanation of some of these dependencies:
-      # https://github.com/ImageMagick/ImageMagick/issues/374#issuecomment-279252866
+          libfontconfig1-dev \
+          aspell-en
 
     - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169 # v2.1.1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,8 @@ jobs:
             html \
             slides \
             linkcheck \
-            SPHINXOPTS='-Wn' \
+            SPHINXOPTS='-Wn --keep-going' \
+            FORCE_COLOR=true \
             STABLE=${{ github.event.inputs.set_stable }} \
             LATEST=${{ github.event.inputs.set_latest }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,10 +109,11 @@ jobs:
             html \
             slides \
             linkcheck \
-            SPHINXOPTS="-Wn -A sidebar_version_name=${version}" \
+            SPHINXOPTS="-Wn --keep-going -A sidebar_version_name=${version}" \
             STABLE=false \
             LATEST=false \
-            BUILDDIR='doc/nightly'
+            BUILDDIR='doc/nightly' \
+            FORCE_COLOR=true
           git -C gh-pages add 'nightly' 'versions.json'
 
       - name: push changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,11 +63,21 @@ jobs:
           flake8
           eslint .
 
-      - name: build
+      - name: (debug only) list language dictionaries
+        if: runner.debug
+        shell: python
+        env:
+          PYENCHANT_VERBOSE_FIND: true
         run: |
-          make html slides spelling linkcheck doctest SPHINXOPTS='-Wn'
+          import enchant
+          print(enchant.list_dicts())
 
-      - name: debug
+      - name: build & test
+        run: |
+          make html slides spelling linkcheck doctest \
+            SPHINXOPTS='-Wn --keep-going' FORCE_COLOR=true
+
+      - name: debug sphinx failure
         if: failure()
         run: |
           cat /tmp/sphinx-err* || true  # sphinx traceback

--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -5,12 +5,8 @@ auth
 authenticator
 bar
 baz
-behavior
-behaviour
 boolean
 booleans
-colored
-coloured
 conf
 config
 configargs
@@ -28,7 +24,6 @@ diff
 diffs
 dir
 dirs
-duration
 durations
 env
 etc
@@ -139,7 +134,6 @@ retrigger
 retriggered
 retriggering
 roadmap
-routines
 runahead
 runnable
 runtime


### PR DESCRIPTION
With the change from `ubuntu-18.04` to `ubuntu-latest`, the `aspell` language dictionaries were no longer installed, so the spellchecker started using `hunspell` instead, which seemed to be falling back on `en_US` despite us setting `en_NZ`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
