### PR TITLE
Get list of template variables for xtriggers from correct place

### DIFF
--- a/src/user-guide/writing-workflows/external-triggers.rst
+++ b/src/user-guide/writing-workflows/external-triggers.rst
@@ -254,7 +254,11 @@ properties:
    because each call is executed in an independent process in the process
    pool. If necessary the filesystem can be used for this purpose.
 
-.. autoenumvalues:: cylc.flow.task_events_mgr.EventData
+.. spelling:word-list::
+
+   vv
+
+.. autoenumvalues:: cylc.flow.xtrigger_mgr.TemplateVariables
 
 Function return values should be as follows:
 


### PR DESCRIPTION
Closes #546 

From cylc.flow.xtrigger_mgr.TemplateVariables, not task_events_mgr.EventData

# How to reproduce bug

```
#!jinja2
# flow.cylc
[scheduler]
    allow implicit tasks = True
[scheduling]
    initial cycle point = 2781-03-21T02:17
    [[graph]]
        R1 = @my_trigger => foo
    [[xtriggers]]
        my_trigger = my_trigger(%({{VAR}})s)
```
```
# lib/python/my_trigger.py
def my_trigger(*args):
    print(*args)
    return (True, {})
```
Running script:
```
cylc install -n foo && cylc play foo -s 'VAR="uuid"'
```
Should return an exception for variables documented which are not actually available as xtrigger template variables such as `suite_uuid` and `uuid`.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

Rebuilt docs available on my internal web space with alleged version 8.99.0.dev

