### PR TITLE
actions: pin to metomi-rose 2.0.x

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: install libs to document
         uses: cylc/cylc-doc/.github/actions/install-libs@master
+        with:
+          metomi-rose-tag: '2.0.x'
 
       - name: create conda envs
         uses: ./docs/.github/actions/create-conda-envs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: install libs to document
         uses: ./docs/.github/actions/install-libs
+        with:
+          metomi-rose-tag: '2.0.x'
 
       - name: checkout gh-pages branch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
       - name: install libs to document (other branches)
         if: github.base_ref != '8.0.x'
         uses: ./.github/actions/install-libs
+        with:
+          metomi-rose-tag: '2.0.x'
 
       - name: install eslint
         run: |

--- a/src/reference/changes.rst
+++ b/src/reference/changes.rst
@@ -61,7 +61,7 @@ Combined Commands
 
 Two new commands have been added as short-cuts for common working patterns:
 
-``cylc vip`` validates, installs, and plays a workflow, and is eqivelent to:
+``cylc vip`` validates, installs, and plays a workflow, and is equivalent to:
 
 .. code-block:: bash
 


### PR DESCRIPTION
* There have been no functional changes to Rose 2.1 yet so we are skipping release.
* Remove this pin when we are ready to build against Rose master again.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
