### PR TITLE
Add vr to cheatsheet

### DIFF
--- a/src/7-to-8/cheat-sheet.rst
+++ b/src/7-to-8/cheat-sheet.rst
@@ -53,15 +53,9 @@ Install a workflow from source and run it:
          rose suite-run
      - ::
 
-         # install from $PWD
-         cylc install
-
-         # run the installed workflow
-         cylc play <name>
-
-         # alternatively:
          # validate, install & play
          cylc vip <name>
+         cylc vip # use $PWD
 
 
 Reloading
@@ -87,22 +81,10 @@ To update a running workflow with changes from the source directory:
          rose suite-run --reload
      - ::
 
-         # re-install from source
-         cylc reinstall <name>
-
-         # reload the worklow
-         cylc reload <name>
-
          # Validate against source;
-         # reinstall
-         cylc vr
-
-.. note::
-
-  ``cylc vr`` is Validate, Reinstall, (Reload or Play). It will:
-
-  * Reload a playing or paused workflow (but not pause/unpause it).
-  * Play a stopped workflow.
+         # Reinstall;
+         # Reload or Play
+         cylc vr <name>
 
 
 Pausing & Unpausing

--- a/src/7-to-8/cheat-sheet.rst
+++ b/src/7-to-8/cheat-sheet.rst
@@ -93,6 +93,17 @@ To update a running workflow with changes from the source directory:
          # reload the worklow
          cylc reload <name>
 
+         # Validate against source;
+         # reinstall
+         cylc vr
+
+.. note::
+
+  ``cylc vr`` is Validate, Reinstall, (Reload or Play). It will:
+
+  * Reload a playing or paused workflow (but not pause/unpause it).
+  * Play a stopped workflow.
+
 
 Pausing & Unpausing
 -------------------

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -997,7 +997,11 @@ Glossary
 
          * :term:`cold start`
          * :term:`start task`
-         * :term:`restart`v
+         * :term:`restart`
+         * :term:`shutdown`
+
+
+   start task
       A start task is :term:`task` in the :term:`graph` from which the
       :term:`scheduler` :term:`starts <start>` running a :term:`workflow` from
       scratch.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -997,11 +997,7 @@ Glossary
 
          * :term:`cold start`
          * :term:`start task`
-         * :term:`restart`
-         * :term:`shutdown`
-
-
-   start task
+         * :term:`restart`v
       A start task is :term:`task` in the :term:`graph` from which the
       :term:`scheduler` :term:`starts <start>` running a :term:`workflow` from
       scratch.


### PR DESCRIPTION
This is a basic addition of VR to the cheatsheet pending larger (and potentially more controversial) changes to the docs.

Served locally at `my-internal/domain/cylc-doc/8.1.1.dev/html/7-to-8/cheat-sheet.html`

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
