### PR TITLE
actions: fix nightly version links

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -37,7 +37,7 @@ def get_versions(builddir):
     yield from pathlib.Path(builddir).glob('[0-9]*.[0-9]*')
     yield from pathlib.Path(builddir).glob('stable')
     yield from pathlib.Path(builddir).glob('latest')
-    yield from pathlib.Path(builddir).glob('nightly')
+    yield from pathlib.Path(builddir).glob('nightly*')
 
 
 def get_formats(builddir):


### PR DESCRIPTION
Follow-on to https://github.com/cylc/cylc-doc/pull/602, the nightly builds ran correctly, but aren't linked from the versions list because of the directory name change.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
