### PR TITLE
Remove broken nightly link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![stable](https://img.shields.io/website?label=stable&up_message=live&url=https%3A%2F%2Fcylc.github.io%2Fcylc-doc%2Fstable%2Fhtml%2Findex.html)](https://cylc.github.io/cylc-doc/stable/html/index.html)
 [![latest](https://img.shields.io/website?label=latest&up_message=live&url=https%3A%2F%2Fcylc.github.io%2Fcylc-doc%2Flatest%2Fhtml%2Findex.html)](https://cylc.github.io/cylc-doc/latest/html/index.html)
-[![nightly](https://img.shields.io/website?label=nightly&labelColor=&up_message=live&url=https%3A%2F%2Fcylc.github.io%2Fcylc-doc%2Fnightly%2Fhtml%2Findex.html)](https://cylc.github.io/cylc-doc/nightly/html/index.html)
 
 Documentation for the Cylc Workflow Engine and its software ecosystem.
 


### PR DESCRIPTION
This badge is now showing as "down" because the nightly builds are now based on the meta release versions. The version numbers will change so there is no longer a static link

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
