### PR TITLE
Fix linkcheck

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -141,8 +141,8 @@ graphviz_dot_args = ['-Gfontname=sans', '-Gbgcolor=none',
                      '-Nfontname=sans']
 
 linkcheck_ignore = [
-    # linkcheck has trouble handling RH readme pages
-    r'https://github.com/metomi/isodatetime.*#.*'
+    # linkcheck has trouble handling GH anchors
+    r'https://github.com/.*#.*'
 ]
 
 nitpick_ignore_regex = [

--- a/src/hyperlinks.rst.include
+++ b/src/hyperlinks.rst.include
@@ -1,7 +1,7 @@
 .. This document contains hyperlink references for use throughout the documentation.
 
 .. _Apollo Client: https://www.apollographql.com/docs/react/
-.. _Configurable HTTP Proxy: https://github.com/AbdealiJK/configurable-http-proxy
+.. _Configurable HTTP Proxy: https://github.com/corridor/configurable-http-proxy
 .. _CurveZMQ: http://curvezmq.org/page:read-the-docs
 .. _Cylc User Guide: https://cylc.github.io/cylc-doc/latest/html/index.html
 .. _Cylc Workflow Design Guide: https://cylc.github.io/cylc-doc/latest/html/workflow-design-guide/index.html
@@ -13,11 +13,11 @@
 .. _FCM User Guide: http://metomi.github.io/fcm/doc/user_guide/
 .. _FCM: https://metomi.github.io/fcm/doc/
 .. _INI: https://en.wikipedia.org/wiki/INI_file
-.. _Jinja2: https://jinja.palletsprojects.com/
+.. _Jinja2: https://jinja.palletsprojects.com/en/3.0.x/
 .. _Jupyter Hub: https://jupyterhub.readthedocs.io/en/stable/
 .. _Jupyter Lab: https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html
 .. _Jupyter Server: https://jupyter-server.readthedocs.io
-.. _Protobuf: https://developers.google.com/protocol-buffers/
+.. _Protobuf: https://protobuf.dev/
 .. _PyGTK: http://www.pygtk.org/
 .. _Python Regular Expressions: https://docs.python.org/2/library/re.html#regular-expression-syntax
 .. _Python: https://www.python.org/

--- a/src/user-guide/writing-workflows/jinja2.rst
+++ b/src/user-guide/writing-workflows/jinja2.rst
@@ -24,7 +24,7 @@ so Jinja2 can appear anywhere in the file.
 
 Embedded Jinja2 code should be reasonably easy to understand for those with
 coding experience; but if not, Jinja2 is well documented `here
-<https://jinja.palletsprojects.com/>`_.
+<Jinja2_>`_.
 
 Uses of Jinja2 in Cylc include:
 
@@ -443,7 +443,7 @@ handled using ``namespace`` objects that allow propagating of changes across sco
 
 For detail, see
 `Jinja2 Template Designer Documentation - Assignments
-<https://jinja.palletsprojects.com/en/2.11.x/templates/#assignments>`_
+<https://jinja.palletsprojects.com/en/3.0.x/templates/#assignments>`_
 
 
 .. _Jinja2RaisingExceptions:

--- a/src/workflow-design-guide/general-principles.rst
+++ b/src/workflow-design-guide/general-principles.rst
@@ -126,7 +126,7 @@ Coding Standards
 When writing your own task scripts make consistent use of appropriate coding
 standards such as:
 
-- `PEP8 for Python <https://www.python.org/dev/peps/pep-0008/>`_
+- `PEP8 for Python <https://peps.python.org/pep-0008/>`_
 - `Google Shell Style Guide for
   Bash <https://google.github.io/styleguide/shell.xml>`_
 


### PR DESCRIPTION
> It appears GitHub has made the Markdown renderer/file viewer require JavaScript which breaks linkcheck anchor checks.

https://github.com/sphinx-doc/sphinx/issues/11484

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
