### PR TITLE
Update scheduling.rst

### DIFF
--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -2165,7 +2165,7 @@ somewhere in the graph with no offset. This prevents unintentional creation of
 off-sequence tasks by an offset error in the graph.
 
 For instance, the following example fails validation with *no cycling sequences
-defined for ``foo``*:
+defined for* ``foo``:
 
 .. code-block:: cylc
 


### PR DESCRIPTION
rst doesn't support nesting formatting styles, so foo gets displayed with the double back ticks showing.

Happy to amend it to move foo inside the italic block if that's better.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
