### PR TITLE
Fix.tutorial

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -147,7 +147,8 @@ graphviz_dot_args = ['-Gfontname=sans', '-Gbgcolor=none',
 
 linkcheck_ignore = [
     # linkcheck has trouble handling GH anchors
-    r'https://github.com/.*#.*'
+    r'https://github.com/.*#.*',
+    r'https://linux.die.net/.*'
 ]
 
 nitpick_ignore_regex = [

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -312,7 +312,7 @@ Start, Stop, Restart
          cylc get-resources api-key
 
       Add the following lines to the ``[runtime]`` section of the
-      :cylc:conf:`flow.cylc` file replacing
+      :cylc:conf:`flow.cylc` file
 
       .. code-block:: cylc
 
@@ -327,8 +327,8 @@ Start, Stop, Restart
       Add three more ``get_observations`` tasks for each of the remaining
       weather stations.
 
-      You will need the API key and the site codes for the other three
-      weather stations, which are:
+      You will need to use the same API key for the other three
+      weather stations, and set the ``SITE_ID`` values, which are:
 
       * Camborne - ``3808``
       * Shetland - ``3005``

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -311,8 +311,8 @@ Start, Stop, Restart
 
          cylc get-resources api-key
 
-      Add the following lines to the bottom of the :cylc:conf:`flow.cylc` file replacing
-      ``xxx...`` with your API key:
+      Add the following lines to the ``[runtime]`` section of the
+      :cylc:conf:`flow.cylc` file replacing
 
       .. code-block:: cylc
 
@@ -327,7 +327,8 @@ Start, Stop, Restart
       Add three more ``get_observations`` tasks for each of the remaining
       weather stations.
 
-      You will need the codes for the other three weather stations, which are:
+      You will need the API key and the site codes for the other three
+      weather stations, which are:
 
       * Camborne - ``3808``
       * Shetland - ``3005``
@@ -379,6 +380,7 @@ Start, Stop, Restart
 
       .. code-block:: bash
 
+         cylc install
          cylc play runtime-tutorial
 
       If all goes well the workflow will startup and the tasks will run and

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -431,6 +431,7 @@ Start, Stop, Restart
       .. code-block:: bash
 
          cylc validate .
+         cylc install
 
       .. TODO: Add advice on what to do if the command fails.
 

--- a/src/user-guide/installing-workflows.rst
+++ b/src/user-guide/installing-workflows.rst
@@ -402,7 +402,8 @@ The run directory now looks as follows:
 
    If your workflow needs to create or install scripts or executables at runtime
    and you don't want Cylc to delete them on re-installation, you can use
-   ``bin`` and ``lib/python`` directories in the :ref:`workflow_share_directories`.
+   ``bin`` and ``lib/python`` directories in the
+   :ref:`workflow share directory<workflow_share_directories>`.
 
 
 Expected Errors

--- a/src/user-guide/installing-workflows.rst
+++ b/src/user-guide/installing-workflows.rst
@@ -402,7 +402,7 @@ The run directory now looks as follows:
 
    If your workflow needs to create or install scripts or executables at runtime
    and you don't want Cylc to delete them on re-installation, you can use
-   ``bin`` and ``lib/python`` directories in the :ref:` workflow share directory <workflow_share_directories>`.
+   ``bin`` and ``lib/python`` directories in the :ref:`workflow_share_directories`.
 
 
 Expected Errors


### PR DESCRIPTION
Prep for course delivered October 2023.

Paired with changes in https://github.com/cylc/cylc-flow/pull/5744

- Clarify runtime tutorial
- Add a `cylc install` to the runtime tutorial.
- Fix broken Symlink
- Exempted `https://linux.die.net/.*` linkcheck tests. The domain seems to have implemented more stringent origin meta checks - [see comment on Element](https://matrix.to/#/!hwZqSYihGPuhDdIzIP:matrix.org/$169591864225544fzfBe:matrix.org?via=matrix.org)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

IMO we should not merge these PR's until @joehickson and I have had a chance to skim the whole tutorial.