### PR TITLE
removed slides from builds until we have hieroglyph working again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,6 @@ jobs:
           make -C docs \
             clean \
             html \
-            slides \
             linkcheck \
             SPHINXOPTS='-Wn --keep-going' \
             FORCE_COLOR=true \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -139,7 +139,6 @@ jobs:
           builddir="nightly_${{ matrix.meta_release }}"
           make -C docs \
             html \
-            slides \
             linkcheck \
             SPHINXOPTS="-Wn --keep-going -A sidebar_version_name=${version}" \
             STABLE=false \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: build & test
         run: |
-          make html slides spelling linkcheck doctest \
+          make html spelling linkcheck doctest \
             SPHINXOPTS='-Wn --keep-going' FORCE_COLOR=true
 
       - name: debug sphinx failure


### PR DESCRIPTION
The [hieroglyph library](https://github.com/nyergler/hieroglyph) is broken at the moment. This PR disables slide builds to work around this for now.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
