### PR TITLE
tutorial: add summary page

### DIFF
--- a/src/reference/index.rst
+++ b/src/reference/index.rst
@@ -1,3 +1,5 @@
+.. _reference:
+
 Reference
 =========
 

--- a/src/tutorial/runtime/index.rst
+++ b/src/tutorial/runtime/index.rst
@@ -17,3 +17,4 @@ This section covers:
    introduction
    runtime-configuration
    configuration-consolidation/index
+   summary

--- a/src/tutorial/runtime/summary.rst
+++ b/src/tutorial/runtime/summary.rst
@@ -1,0 +1,38 @@
+Tutorial Summary
+================
+
+You've made it to the end of the Cylc tutorial!
+
+The Cylc tutorial aims to introduce you to the main concepts in Cylc to
+prepare you for working with and writing Cylc workflows.
+But there is so much more we didn't have time for.
+
+:ref:`Rose Tutorial <Rose Tutorial>`
+   `Rose`_ is a tool for creating configurable applications. It's often used
+   with Cylc to configure more complex tasks, or even the workflow itself.
+   
+   Rose configurations can have metadata, support validation and can be edited
+   using a GUI.
+   
+   You might want to try the :ref:`Rose Tutorial` if these things are of interest.
+:ref:`Further Topics <tutorials.furthertopics>`
+   There some extra tutorials which cover some of the things the main tutorial
+   doesn't in the :ref:`further topics section <tutorials.furthertopics>`.
+`Discourse`_
+   If you get stuck, encounter an issue, have a question, or just fancy a chat
+   about Cylc, feel free to reach out to the Cylc community on our `Discourse`_
+   forum.
+   
+   We also make announcements (e.g. new Cylc releases) on the forum, so it's a
+   good to keep an eye on it.
+:ref:`User Guide <user guide>`
+   There is a comprehensive :ref:`user guide` which goes into Cylc's
+   capabilities in detail.
+:ref:`Workflow Design Guide <workflow design guide>`
+   This covers recommended code style and best practice.
+:ref:`Reference <reference>`
+   The reference section contains all sorts of technical details.
+
+   It also lists all of the configurations Cylc supports for workflow
+   definition :cylc:conf:`flow.cylc`, and for site/user setup
+   :cylc:conf:`global.cylc`.

--- a/src/user-guide/index.rst
+++ b/src/user-guide/index.rst
@@ -1,3 +1,5 @@
+.. _user guide:
+
 User Guide
 ==========
 

--- a/src/workflow-design-guide/index.rst
+++ b/src/workflow-design-guide/index.rst
@@ -1,4 +1,4 @@
-.. SDG:
+.. _workflow design guide:
 
 Workflow Design Guide
 =====================


### PR DESCRIPTION
Action from washup at the end of a recent training session.

When presenting in person, we had a summary slide to help signpost useful resources, this jams it in at the end of the runtime tutorial, so that pressing "next" will take you to the summary page.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
