### PR TITLE
Nightly: checkout correct branch of cylc-doc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,10 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      meta-releases: ${{ steps.set-meta-releases.outputs.meta-releases }}
+      list: ${{ steps.set-meta-releases.outputs.meta-releases }}
+      dict: ${{ steps.set-meta-releases.outputs.meta-releases-dict }}
+
     steps:
-      - name: install libs
-        id: set-meta-releases
+      - id: set-meta-releases
         uses: cylc/release-actions/set-meta-releases@v1
 
   deploy:
@@ -52,11 +53,13 @@ jobs:
     strategy:
       # run one job per meta-release
       matrix:
-        meta_release: ${{ fromJson(needs.set-meta-releases.outputs.meta-releases) }}
+        meta_release: ${{ fromJson(needs.set-meta-releases.outputs.list) }}
       # don't stop if one job fails
       fail-fast: false
       # only run one job at a time
       max-parallel: 1
+    env:
+      META_DICT: ${{ needs.set-meta-releases.outputs.dict }}
     steps:
       - name: configure python
         uses: actions/setup-python@v4
@@ -66,15 +69,14 @@ jobs:
       - name: checkout cylc-doc
         uses: actions/checkout@v4
         with:
+          ref: ${{ fromJson(env.META_DICT)[matrix.meta_release]['cylc/cylc-doc'] }}
           path: docs
 
       - name: install dependencies
         uses: ./docs/.github/actions/install-dependencies
 
-      - name: install cylc-doc
-        run: pip install "${{ github.workspace }}/docs[all]"
-
       - name: install libs to document
+        id: install-libs
         uses: cylc/release-actions/install-cylc-components@v1
         with:
           meta_release: ${{ matrix.meta_release }}


### PR DESCRIPTION
We were checking out master even when we were supposed to be building 8.2.x.

Needs https://github.com/cylc/release-actions/pull/60

Demo: https://github.com/MetRonnie/cylc-doc/actions/runs/6666073608 - they each failed because I don't have a `gh-pages` branch on my fork, but the important thing is to look at what ref cylc-doc was checked out at

![image](https://github.com/cylc/cylc-doc/assets/61982285/943ed210-d501-4f2b-918c-60d6017172b4)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
