### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,9 @@ jobs:
       - name: install dependencies
         uses: ./docs/.github/actions/install-dependencies
 
+      - name: install cylc-doc
+        run: pip install ./docs/
+
       - name: install libs to document
         id: install-libs
         uses: cylc/release-actions/install-cylc-components@v1


### PR DESCRIPTION
Fixes `sphinx-build not found` error

Tested at@: https://github.com/cylc/cylc-doc/actions/runs/7102653132

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
