### PR TITLE
Added a seealso link from the top of the Cylc lint doc...

### DIFF
--- a/src/user-guide/writing-workflows/configuration.rst
+++ b/src/user-guide/writing-workflows/configuration.rst
@@ -153,7 +153,14 @@ show an inlined copy of the workflow with correct line numbers.
 ``cylc lint``
 ^^^^^^^^^^^^^
 
+.. seealso::
+
+   :ref:`How to configure Cylc lint at project level <lint.pyproject.toml>`
+   using a ``pyproject.toml``.
+
 .. automodule:: cylc.flow.scripts.lint
+
+.. _lint.pyproject.toml:
 
 Configure ``cylc lint`` at project level
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
... to the section on using a pyproject.toml, because the list of error codes is now rather long.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
