### PR TITLE
Add words to spellcheck dictionary

### DIFF
--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -11,6 +11,7 @@ backticks
 baz
 boolean
 booleans
+cfg
 changelog
 changelogs
 conf
@@ -20,6 +21,7 @@ configs
 coroutine
 coroutines
 cprofile
+ctx
 cyclepoint
 dataset
 datasets
@@ -72,6 +74,8 @@ iso
 iterable
 jitter
 jobscript
+kwarg
+kwargs
 latin
 lifecycle
 linearization


### PR DESCRIPTION
Autodocumented exceptions introduced in #680 causing spellcheck to fail

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
