### PR TITLE
spelling: add subprocess to dictionary

### DIFF
--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -167,6 +167,7 @@ subcommands
 subdir
 subdirectories
 subdirectory
+subprocess
 subprocesses
 subshell
 subshelled


### PR DESCRIPTION
Fix [failing](https://github.com/cylc/cylc-doc/actions/runs/8522868514/job/23343967099) spell check on 8.2.x.