### PR TITLE
Warn of dependence on plugin fileinstall

### DIFF
--- a/src/7-to-8/cheat-sheet.rst
+++ b/src/7-to-8/cheat-sheet.rst
@@ -25,10 +25,21 @@ Check the workflow configuration for errors:
      - ::
 
          # validate from $PWD
-         rose suite-run --validate
+         rose suite-run --validate-suite-only
      - ::
 
          cylc validate <name/path>
+
+.. note::
+
+   If you are using a plugin (such as :ref:`cylc rose`) to install files **and**
+   your config includes those files:
+
+   You will still need to install the workflow and then
+   validate the installed workflow.
+
+   I.e. ``cylc install && cylc validate <workflow id>``.
+
 
 Installing & Running
 --------------------


### PR DESCRIPTION
## Summary

Cylc cannot validate ahead of plugin (cylc rose) file installation if validation relies on files installed.

## Example

```
# rose-suite.conf
[file:foo.rc]
source="/some/path/foo.rc"
```

```
# flow.cylc
%% include foo.rc
```

Built update at http://localserver..../cylc-doc/8.3.0.20240410A/html/7-to-8/cheat-sheet.html#admonition-0

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
