### PR TITLE
Some doc updates for 8.3.0.dev changes.

### DIFF
--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -34,8 +34,9 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
     branching)
 
 - ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
-  so the scheduler will retain all other tasks with :term:`final status`
-  in the :term:`n=0 window <n-window>`.
+  so in the absence of suicide triggers the scheduler will retain other
+  :term:`final status` tasks in the :term:`n=0 window <n-window>` to stall the
+   workflow.
 
   - (in Cylc 8, **all** outputs are *required* unless marked as
     :ref:`*optional* <User Guide Optional Outputs>` by the new ``?`` syntax)

--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -36,7 +36,7 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
 - ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
   so in the absence of suicide triggers the scheduler will retain other
   :term:`final status` tasks in the :term:`n=0 window <n-window>` to stall the
-   workflow.
+  workflow.
 
   - (in Cylc 8, **all** outputs are *required* unless marked as
     :ref:`*optional* <User Guide Optional Outputs>` by the new ``?`` syntax)

--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -33,7 +33,7 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
   - (Cylc 8 spawns tasks on demand, and suicide triggers are not needed for
     branching)
 
-- ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
+- ``succeeded`` task outputs are :ref:`required <User Guide Required Outputs>`,
   so in the absence of suicide triggers the scheduler will retain other
   :term:`final status` tasks in the :term:`n=0 window <n-window>` to stall the
   workflow.

--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -34,7 +34,8 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
     branching)
 
 - only ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
-  meaning the scheduler will retain tasks that do not succeed as incomplete
+  so the scheduler will retain all non-succeeded :term:`finished tasks <finished task>`
+  in the :term:`n=0 window <n-window>`.
 
   - (in Cylc 8, **all** outputs are *required* unless marked as
     :ref:`*optional* <User Guide Optional Outputs>` by the new ``?`` syntax)

--- a/src/7-to-8/major-changes/compatibility-mode.rst
+++ b/src/7-to-8/major-changes/compatibility-mode.rst
@@ -33,8 +33,8 @@ The ``suite.rc`` filename triggers a backward compatibility mode in which:
   - (Cylc 8 spawns tasks on demand, and suicide triggers are not needed for
     branching)
 
-- only ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
-  so the scheduler will retain all non-succeeded :term:`finished tasks <finished task>`
+- ``succeeded`` task outputs are :ref:`*required* <User Guide Required Outputs>`,
+  so the scheduler will retain all other tasks with :term:`final status`
   in the :term:`n=0 window <n-window>`.
 
   - (in Cylc 8, **all** outputs are *required* unless marked as

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -121,14 +121,16 @@ Optional and Required Task Outputs
    * User Guide::ref:`User Guide Optional Outputs`
 
 By default, all Cylc 8 tasks are required to succeed - i.e., success is
-a :term:`required output`. Otherwise they will be marked
-as :term:`incomplete tasks<incomplete task>` needing user intervention.
-In a workflow with incomplete tasks, if there is nothing left to do, the
-scheduler will :term:`stall` rather than shut down.
+a :term:`required output`. Tasks that :term:`finish <finished task>`
+without completing their required outputs get retained in the
+:term:`n=0 window <n-window>` pending user intervention, which
+will :term:`stall` the workflow.
 
-Alternatively, task outputs can be marked as :term:`optional <optional output>`.
-This supports :term:`graph branching` and it allows the scheduler to
-correctly diagnose :term:`workflow completion`.
+Alternatively, outputs can be marked as :term:`optional <optional output>`,
+which allows :term:`optional graph branching <graph branching>`.
+
+This allows the scheduler to correctly diagnose :term:`workflow completion`.
+
 
 Platform Awareness
 ------------------

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -121,10 +121,9 @@ Optional and Required Task Outputs
    * User Guide::ref:`User Guide Optional Outputs`
 
 By default, all Cylc 8 tasks are required to succeed - i.e., success is
-a :term:`required output`. Tasks that :term:`finish <finished task>`
-without completing their required outputs get retained in the
-:term:`n=0 window <n-window>` pending user intervention, which
-will :term:`stall` the workflow.
+a :term:`required output`. Tasks with :term:`final status` and incomplete
+outputs get retained in the :term:`n=0 window <n-window>` pending user
+intervention, which will :term:`stall` the workflow.
 
 Alternatively, outputs can be marked as :term:`optional <optional output>`,
 which allows :term:`optional graph branching <graph branching>`.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -106,11 +106,11 @@ Glossary
    window
    n-window
    active window
-      The UI provides a :term:`graph`-based window or view of the workflow at
+      The GUI provides a :term:`graph`-based window or view of the workflow at
       runtime, including tasks out to ``n`` graph edges from current
       :term:`active tasks <active task>`.
 
-      Active tasks form the ``n=0`` core of the :term:`n-window`.
+      Active tasks form the ``n=0``` window.
 
       .. seealso::
 
@@ -1383,17 +1383,6 @@ Glossary
       - ``:succeeded``, or ``:failed``
 
 
-   prerequisite
-   task prerequisite
-      A task's prerequisites are the :term:`outputs <task output>` of
-      parent tasks upstream in the graph that must be completed before
-      it can run. Tasks are said to "depend on" their prerequisites, hence
-      the term :term:`dependency graph <graph>`.
-
-      Tasks can depend on :term:`external triggers <xtrigger>` as well as
-      the outputs of other, upstream, tasks.
-
-
    output
    task output
       Task outputs mark the progression of a :term:`task` from waiting (for
@@ -1426,8 +1415,9 @@ Glossary
       A task's outputs are *complete* if its *output completion condition* 
       is satisfied.
 
-      The completion condition can be defined by the user, or otherwise
-      it is automatically generated according to the rules:
+      The completion condition can be defined by the user in
+      :cylc:conf:`flow.cylc[runtime][<namespace>]completion`,
+      otherwise it is automatically generated according to the rules:
 
       - All :term:`required outputs <required output>` (referenced in the graph)
         must be completed.
@@ -1444,10 +1434,13 @@ Glossary
       the workflow.
 
 
+   prerequisite
    dependence
    dependency
       Dependencies in the :term:`graph` show how :term:`tasks <task>` depend on
       some combination of the :term:`outputs <task output>` of other tasks.
+      These dependencies are also called the prerequisites of the downstream.
+      task.
 
       For example, in the following dependency the task ``baz`` depends on both
       ``foo`` and ``bar`` succeeding:
@@ -1461,6 +1454,8 @@ Glossary
           * :term:`task trigger`
           * :term:`conditional dependence`
           * :term:`intercycle dependence`
+
+      Tasks can also depend on :term:`external triggers <xtrigger>`.
 
 
    conditional dependence

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -110,7 +110,7 @@ Glossary
       runtime, including tasks out to ``n`` graph edges from current
       :term:`active tasks <active task>`.
 
-      Active tasks form the ``n=0``` window.
+      Active tasks form the ``n=0`` window.
 
       .. seealso::
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -76,7 +76,8 @@ Glossary
 
       Active tasks are:
 
-      - Tasks which have some, but not all of their prerequisites satisfied.
+      - Tasks which have some, but not all of their
+        :term:`prerequisites <prerequisite>` satisfied.
       - ``waiting`` tasks, that are actively waiting on:
 
         - :term:`xtriggers <xtrigger>`.
@@ -567,7 +568,7 @@ Glossary
       if the :term:`wallclock time` exceeds some offset from the cycle point.
 
       Expired is a :term:`final status` - an expired task will not run
-      even if its prerequisites get satisfied.
+      even if its :term:`prerequisites <prerequisite>` get satisfied.
 
       The associated ``:expire`` :term:`output <task output>` can be used to
       trigger other tasks. It must be marked as an :term:`optional output`,
@@ -1384,7 +1385,7 @@ Glossary
 
    prerequisite
    task prerequisite
-      A task's prerequisites are the :term:`outputs <task outputs>` of
+      A task's prerequisites are the :term:`outputs <task output>` of
       parent tasks upstream in the graph that must be completed before
       it can run. Tasks are said to "depend on" their prerequisites, hence
       the term :term:`dependency graph <graph>`.
@@ -1769,6 +1770,7 @@ Glossary
 
       If no active tasks remain and all external constraints are satisfied,
       but the n=0 window contains tasks waiting with partially satisfied
-      :term:`prerequisites`, or tasks with :term:`final status` and
-        :term:`incomplete outputs <output completion>`, then the workflow is
+      :term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
+      :term:`incomplete outputs <output completion>`, then the workflow is
       not complete and the scheduler will :term:`stall` pending manual intervention.
+

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1439,8 +1439,6 @@ Glossary
    dependency
       Dependencies in the :term:`graph` show how :term:`tasks <task>` depend on
       some combination of the :term:`outputs <task output>` of other tasks.
-      These dependencies are also called the prerequisites of the downstream.
-      task.
 
       For example, in the following dependency the task ``baz`` depends on both
       ``foo`` and ``bar`` succeeding:

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -86,7 +86,7 @@ Glossary
 
       - ``preparing`` tasks - i.e. tasks in the process of submitting jobs
       - ``submitted`` and ``running`` tasks - i.e. those with active jobs
-      - tasks that finished without completing their
+      - tasks that reached a :term:`final status` without completing their
         :term:`required outputs <required output>`
         (e.g. a task failed where success was required).
 
@@ -570,7 +570,7 @@ Glossary
       Tasks in :term:`datetime cycling` workflows can be configured to *expire*
       if the :term:`wallclock time` exceeds some offset from the cycle point.
 
-      Expired is a :term:`final task status` - an expired task will not run
+      Expired is a :term:`final status` - an expired task will not run
       even if its prerequisites get satisfied.
       
       The associated ``:expire`` :term:`output <task output>` can be used to
@@ -862,9 +862,8 @@ Glossary
 
 
    job
-      Jobs are the real processes that run on a computer to realise
-      :term:`tasks <task>` in a :term:`workflow`. In Cylc, they are
-      implemented by :term:`job scripts
+      Jobs are the real processes that :term:`tasks <task>` represent in
+      a :term:`workflow`. In Cylc, they are implemented by :term:`job scripts
       <job script>` prepared by the :term:`scheduler`.
 
 
@@ -1371,11 +1370,10 @@ Glossary
          * :ref:`Cylc User Guide <FamilyTriggers>`
 
 
-   final task status
-   finished task
-      A finished task has achieved a final task status, i.e., expired,
-      submit-failed, succeeded, or failed. Finished tasks cannot change
-      state again except by manual intervention (e.g. by retriggering).
+   final status
+      A task that has achieved a final status (expired, submit-failed,
+      succeeded, or failed) will not change state in the workflow, except by
+      manual intervention.
 
 
    standard output
@@ -1413,6 +1411,8 @@ Glossary
          foo => bar  # means foo:succeeded => bar
 
 
+   complete
+   incomplete
    output completion
    output completion condition
       A task's outputs are *complete* if its *output completion condition* 
@@ -1428,11 +1428,12 @@ Glossary
         submit-fails.
       - Or, if expiry is optional, then the outputs are complete if it expires.
 
-      Tasks that :term:`finish <finished task>` with
-      :term:`complete outputs <output completion>`
-      have done their job, allowing the workflow to move on.
+      Tasks that achieve a :term:`final status` with
+      :term:`complete outputs <output completion>` have done their job in the
+      workflow, allowing the workflow to move on.
       
-      Tasks that finish with :term:`incomplete outputs <output completion>`
+      Tasks that achieve a final status with
+      :term:`incomplete outputs <output completion>`
       are retained in :term:`n=0 <n-window>` pending user
       intervention, and will :term:`stall` the workflow.
 
@@ -1567,7 +1568,7 @@ Glossary
    expected output
       Task outputs that are not marked as :term:`optional <optional output>`
       in the :term:`graph` must be completed at runtime. If a task
-      :term:`finishes <finished task>` without completing its required
+      achieves a :term:`final status` without completing its required
       outputs, the :term:`scheduler` will keep it in the
       :term:`n=0 window <n-window>` pending user intervention.
 
@@ -1581,8 +1582,9 @@ Glossary
    stalled state
       In a stalled workflow, there is nothing more the scheduler can do,
       but it stays up for a while awaiting manual intervention because
-      the presence of :term:`incomplete <output completion>` tasks in
-      the :term:`n=0 window <n-window>` implies that the workflow has not successfully
+      the presence of :term:`incomplete <output completion>` tasks, or
+      partially satisfied tasks, in the :term:`n=0 window <n-window>`
+      implies that the workflow has not successfully
       run to :term:`completion <workflow completion>`.
 
       Stalls are usually, but not always, caused by unexpected task failures:

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -128,9 +128,9 @@ Special Case: Triggering ``n=0`` Tasks
 
    - Triggering a task with a submitted or running job has no effect
      (it is already triggered).
-   - Triggering other :term:`active tasks <active task>`, including
-     :term:`incomplete <output completion>` tasks with a :term:`final status`,
-     queues them to run in the same flow.
+   - Triggering other :term:`n=0 tasks <n-window>`, including tasks with
+     :term:`incomplete outputs <output completion>` queues them to run in
+     the flow that they already belong to.
 
 
 .. _flow-merging:
@@ -145,8 +145,9 @@ of itself (same task ID) already there, the two will merge and carry both
 Flow merging is necessary because :term:`active <active task>` task IDs
 must be unique.
 
-If original task instance has a :term:`final status` but is
-:term:`incomplete <output completion>` the merged task will be reset to
+If the original task instance has a :term:`final status` (and has been retained
+in the :term:`n=0 window <n-window>` with
+:term:`incomplete outputs <output completion>`) the merged task will be reset to
 run again without manual intervention.
 
 

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -128,9 +128,9 @@ Special Case: Triggering ``n=0`` Tasks
 
    - Triggering a task with a submitted or running job has no effect
      (it is already triggered).
-   - Triggering other :term:`active tasks <active task>` e.g. (a waiting
-     task which is held) queues it to run in the same flow.
-   - Triggering an :term:`incomplete task` queues it to re-run in the same flow.
+   - Triggering other :term:`active tasks <active task>` (including
+     :term:`incomplete <output completion>`
+     :term:`finished <finished task>` tasks) queues them to run in the same flow.
 
 
 .. _flow-merging:
@@ -138,28 +138,16 @@ Special Case: Triggering ``n=0`` Tasks
 Flow Merging in ``n=0``
 -----------------------
 
-If a task spawning into the ``n=0`` :term:`window` finds another instance
-of itself already there (i.e., same name and cycle point, different flow
-number) a single instance will carry both (sets of) flow numbers forward from
-that point. Downstream tasks belong to both flows.
+If a task spawning into the :term:`n=0 window <n-window>` finds another instance
+of itself (same task ID) already there, the two will merge and carry both
+(sets of) flow numbers forward. Downstream tasks will belong to both flows.
 
-Flow merging in ``n=0`` means flows are not completely independent. One flow
-might not be able to entirely overtake another because one or more of its tasks
-might merge in ``n=0``. Merging is necessary while task IDs - and associated
-log directory paths etc. - do not incorporate flow numbers, because task IDs
-must be unique in the :term:`active task pool`.
+Flow merging is necessary because :term:`active <active task>` task IDs
+must be unique.
 
-Merging with Incomplete tasks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:term:`Incomplete<incomplete>` tasks are retained in the active window in
-expectation of retriggering to complete :term:`required outputs<required
-output>` and continue their flow.
-
-If another flow encounters an incomplete task (i.e. if another instance of the
-same task collides with it in the ``n=0`` :term:`active window`) the task will
-run again and carry both flow numbers forward if it successfully completes its
-required outputs.
+If original task instance is :term:`finished <finished task>` but
+:term:`incomplete <output completion>` the merged task will be reset to
+run again without manual intervention.
 
 
 Stopping Flows
@@ -168,7 +156,7 @@ Stopping Flows
 By default, ``cylc stop`` halts the workflow and shuts the scheduler down.
 
 It can also stop specific flows: ``cylc stop --flow=N`` removes the flow number
-``N`` from tasks in the :term:`active task pool`. Tasks that have no flow
+``N`` from :term:`active tasks <active task>`. Tasks that have no flow
 numbers left as a result do not spawn children at all. If there are no active
 flows left, the scheduler shuts down.
 

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -128,9 +128,9 @@ Special Case: Triggering ``n=0`` Tasks
 
    - Triggering a task with a submitted or running job has no effect
      (it is already triggered).
-   - Triggering other :term:`active tasks <active task>` (including
-     :term:`incomplete <output completion>`
-     :term:`finished <finished task>` tasks) queues them to run in the same flow.
+   - Triggering other :term:`active tasks <active task>`, including
+     :term:`incomplete <output completion>` tasks with a :term:`final status`,
+     queues them to run in the same flow.
 
 
 .. _flow-merging:
@@ -145,7 +145,7 @@ of itself (same task ID) already there, the two will merge and carry both
 Flow merging is necessary because :term:`active <active task>` task IDs
 must be unique.
 
-If original task instance is :term:`finished <finished task>` but
+If original task instance has a :term:`final status` but is
 :term:`incomplete <output completion>` the merged task will be reset to
 run again without manual intervention.
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -21,9 +21,10 @@ alive for 1 hour (by default) awaiting user intervention
 to allow the workflow to continue.
 
 A stall can be caused by tasks with partially satisfied
-prerequisites or tasks that finished incomplete. However,
-partially satisfied prerequisites normally result from
-upstream tasks finishing incomplete.
+prerequisites or tasks that achieved a :term:`final status`
+with incomplete outputs. Partially satisfied prerequisites
+normally result from incomplete tasks with final status 
+upstream in the graph.
 
 Restarting a stalled workflow resets the stall timer.
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -3,9 +3,19 @@
 Workflow Completion
 ===================
 
-If there is nothing more to run (according to the graph) and there are no
-:term:`incomplete <output completion>` tasks present in :term:`n=0 <n-window>`
-the workflow is complete and the scheduler will shut down automatically. 
+   A workflow is complete, and the scheduler will automatically
+   :term:`shut down <shutdown>`, if no tasks remain in the
+   :term:`n=0 <n-window>`.
+
+   That is, all active tasks have finished, and no tasks remain waiting on
+   :term:`prerequisites <prerequisite>` or "external" constraints (such as
+   :term:`xtriggers <xtrigger>` or task :term:`hold`).
+
+   If no active tasks remain and all external constraints are satisfied,
+   but the n=0 window contains tasks waiting with partially satisfied
+   :term:`prerequisites`, or tasks with :term:`final status` and
+     :term:`incomplete outputs <output completion>`, then the workflow is
+   not complete and the scheduler will :term:`stall` pending manual intervention.
 
 
 .. _scheduler stall:
@@ -13,29 +23,17 @@ the workflow is complete and the scheduler will shut down automatically.
 Scheduler Stall
 ===============
 
-If there is nothing more to run, but there are
-:term:`incomplete <output completion>` tasks present in the
-:term:`n=0 window <n-window>` the workflow did not run to
-completion, so the scheduler will :term:`stall` and stay
-alive for 1 hour (by default) awaiting user intervention
-to allow the workflow to continue.
+A stalled workflow has not run to :term:`completion <workflow completion>`
+but cannot continue without manual intervention. 
 
-A stall can be caused by tasks with partially satisfied
-prerequisites or tasks that achieved a :term:`final status`
-with incomplete outputs. Partially satisfied prerequisites
-normally result from incomplete tasks with final status 
-upstream in the graph.
+A stalled scheduler stays alive for a configurable timeout period
+pending manual intervention. If it shuts down (on the stall timeout
+or otherwise) it will remain in the stalled state on restart.
 
-Restarting a stalled workflow resets the stall timer.
-
-
-.. note::
-
-   Partially satisfied prerequisites can also cause a stall. If ``a & b => c``,
-   and ``a`` succeeds but ``b`` never even runs, the scheduler will take
-   partial completion of ``c``'s prerequisites as a sign that the workflow did
-   not run to completion as expected.
-
+Stalls are often caused by unexpected task failures, either directly (tasks
+with :term:`final status` and :term:`incomplete outputs <output completion>`)
+or indirectly (tasks with partially satisfed prerequisites, downstream of an
+unexpected failure).
 
 .. warning::
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -13,8 +13,8 @@ Workflow Completion
 
    If no active tasks remain and all external constraints are satisfied,
    but the n=0 window contains tasks waiting with partially satisfied
-   :term:`prerequisites`, or tasks with :term:`final status` and
-     :term:`incomplete outputs <output completion>`, then the workflow is
+   :term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
+   :term:`incomplete outputs <output completion>`, then the workflow is
    not complete and the scheduler will :term:`stall` pending manual intervention.
 
 
@@ -32,8 +32,8 @@ or otherwise) it will remain in the stalled state on restart.
 
 Stalls are often caused by unexpected task failures, either directly (tasks
 with :term:`final status` and :term:`incomplete outputs <output completion>`)
-or indirectly (tasks with partially satisfed prerequisites, downstream of an
-unexpected failure).
+or indirectly (tasks with partially satisfied :term:`prerequisites <prerequisite>`,
+downstream of an unexpected failure).
 
 .. warning::
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -4,8 +4,8 @@ Workflow Completion
 ===================
 
 If there is nothing more to run (according to the graph) and there are no
-:term:`incomplete tasks <incomplete task>` present, the scheduler will report
-workflow completion and shut down when current active tasks finish. 
+:term:`incomplete <output completion>` tasks present in :term:`n=0 <n-window>`
+the workflow is complete and the scheduler will shut down automatically. 
 
 
 .. _scheduler stall:
@@ -13,16 +13,19 @@ workflow completion and shut down when current active tasks finish.
 Scheduler Stall
 ===============
 
-If there is nothing more to run (according to the graph) but there are
-:term:`incomplete tasks <incomplete task>` present, the scheduler will
-:term:`stall` and stay alive for 1 hour (by default) awaiting user intervention
+If there is nothing more to run, but there are
+:term:`incomplete <output completion>` tasks present in the
+:term:`n=0 window <n-window>` the workflow did not run to
+completion, so the scheduler will :term:`stall` and stay
+alive for 1 hour (by default) awaiting user intervention
 to allow the workflow to continue.
 
-The presence of incomplete tasks means that the workflow did not run to
-completion as expected, because some :term:`required task outputs
-<required output>` were not completed at runtime.
+A stall can be caused by tasks with partially satisfied
+prerequisites or tasks that finished incomplete. However,
+partially satisfied prerequisites normally result from
+upstream tasks finishing incomplete.
 
-Restarting a stalled workflow triggers a new stall timer.
+Restarting a stalled workflow resets the stall timer.
 
 
 .. note::

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -3,19 +3,19 @@
 Workflow Completion
 ===================
 
-   A workflow is complete, and the scheduler will automatically
-   :term:`shut down <shutdown>`, if no tasks remain in the
-   :term:`n=0 <n-window>`.
+A workflow is complete, and the scheduler will automatically
+:term:`shut down <shutdown>`, if no tasks remain in the
+:term:`n=0 <n-window>`.
 
-   That is, all active tasks have finished, and no tasks remain waiting on
-   :term:`prerequisites <prerequisite>` or "external" constraints (such as
-   :term:`xtriggers <xtrigger>` or task :term:`hold`).
+That is, all active tasks have finished, and no tasks remain waiting on
+:term:`prerequisites <prerequisite>` or "external" constraints (such as
+:term:`xtriggers <xtrigger>` or task :term:`hold`).
 
-   If no active tasks remain and all external constraints are satisfied,
-   but the n=0 window contains tasks waiting with partially satisfied
-   :term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
-   :term:`incomplete outputs <output completion>`, then the workflow is
-   not complete and the scheduler will :term:`stall` pending manual intervention.
+If no active tasks remain and all external constraints are satisfied,
+but the n=0 window contains tasks waiting with partially satisfied
+:term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
+:term:`incomplete outputs <output completion>`, then the workflow is
+not complete and the scheduler will :term:`stall` pending manual intervention.
 
 
 .. _scheduler stall:

--- a/src/user-guide/task-implementation/job-scripts.rst
+++ b/src/user-guide/task-implementation/job-scripts.rst
@@ -185,7 +185,7 @@ configured).
 Task messages are validated by:
 
 .. autoclass:: cylc.flow.unicode_rules.TaskMessageValidator
-   :no-index:
+   :noindex:
 
 .. _job-scripts.aborting-on-error:
 

--- a/src/user-guide/writing-workflows/external-triggers.rst
+++ b/src/user-guide/writing-workflows/external-triggers.rst
@@ -126,11 +126,9 @@ The workflow state trigger function signature looks like this:
 
 .. autofunction:: cylc.flow.xtriggers.workflow_state.workflow_state
 
-The first three arguments are compulsory; they single out the target workflow name
-(``workflow``) task name (``task``) and cycle point
-(``point``). The function arguments mirror the arguments and options of
-the ``cylc workflow-state`` command - see
-``cylc workflow-state --help`` for documentation.
+The first argument identifies the target workflow, cycle, task, and status or
+output trigger name. The function arguments mirror the arguments and options of
+the ``cylc workflow-state`` command - see ``cylc workflow-state --help``.
 
 As a simple example, consider the following "upstream"
 workflow (which we want to trigger off of):
@@ -158,8 +156,8 @@ Some important points to note about this:
 - The ``workflow_state`` trigger function, like the
   ``cylc workflow-state`` command, must have read-access to the upstream
   workflow's public database.
-- The cycle point argument is supplied by a string template
-  ``%(point)s``. The string templates available to trigger function
+- The cycle point is supplied by a string template
+  ``%(point)s``. The string templates available to trigger functions
   arguments are described in :ref:`Custom Trigger Functions`).
 
 The return value of the ``workflow_state`` trigger function looks like
@@ -168,20 +166,17 @@ this:
 .. code-block:: python
 
    results = {
-       'workflow': workflow,
-       'task': task,
-       'point': point,
-       'offset': offset,
-       'status': status,
-       'message': message,
-       'cylc_run_dir': cylc_run_dir
+       'workflow_id': workflow_id,
+       'task_id': task_id,
+       'task_selector': task_selector,
+       'flow_num': flow_num,
    }
    return (satisfied, results)
 
 The ``satisfied`` variable is boolean (value True or False, depending
 on whether or not the trigger condition was found to be satisfied). The
-``results`` dictionary contains the names and values of all of the
-target workflow state parameters. Each item in it gets qualified with the
+``results`` dictionary contains the names and values of the
+target workflow state parameters. Each name gets qualified with the
 unique trigger label ("upstream" here) and passed to the environment of
 dependent tasks (the members of the ``FAM`` family in this case).
 To see this, take a look at the job script for one of the downstream tasks:
@@ -194,18 +189,16 @@ To see this, take a look at the job script for one of the downstream tasks:
        # TASK RUNTIME ENVIRONMENT:
        export upstream_workflow upstream_cylc_run_dir upstream_offset \
          upstream_message upstream_status upstream_point upstream_task
-       upstream_workflow="up"
-       upstream_cylc_run_dir="/home/vagrant/cylc-run"
-       upstream_offset="None"
-       upstream_message="data ready"
-       upstream_status="succeeded"
-       upstream_point="2011"
-       upstream_task="foo"}
+       upstream_workflow_id="up"
+	   upstream_task_id="2011/foo"
+       upstream_selector="succeeded"
+	   upstream_flow_num="1"
+   }
    ...
 
 .. note::
 
-   The task has to know the name (label) of the external trigger that it
+   The dependent task has to know the name of the xtrigger that it
    depends on - "upstream" in this case - in order to use this information.
    However the name could be given to the task environment in the workflow
    configuration.

--- a/src/user-guide/writing-workflows/external-triggers.rst
+++ b/src/user-guide/writing-workflows/external-triggers.rst
@@ -402,6 +402,7 @@ success. The function signature is:
 .. automodule:: cylc.flow.xtriggers.xrandom
    :members: xrandom, validate
    :member-order: bysource
+   :noindex:
 
 An example xrandom trigger workflow:
 

--- a/src/user-guide/writing-workflows/external-triggers.rst
+++ b/src/user-guide/writing-workflows/external-triggers.rst
@@ -166,10 +166,13 @@ this:
 .. code-block:: python
 
    results = {
-       'workflow_id': workflow_id,
-       'task_id': task_id,
-       'task_selector': task_selector,
-       'flow_num': flow_num,
+       'workflow': workflow_id,
+       'task': task_name,
+       'point': cycle_point,
+       'status': task_status,  # or
+	   'trigger': task_output_trigger,  # or
+	   'message': task_output_message,
+       'flow_num': flow_num  # if given
    }
    return (satisfied, results)
 
@@ -189,10 +192,10 @@ To see this, take a look at the job script for one of the downstream tasks:
        # TASK RUNTIME ENVIRONMENT:
        export upstream_workflow upstream_cylc_run_dir upstream_offset \
          upstream_message upstream_status upstream_point upstream_task
-       upstream_workflow_id="up"
-	   upstream_task_id="2011/foo"
-       upstream_selector="succeeded"
-	   upstream_flow_num="1"
+       upstream_workflow="up"
+	   upstream_task="foo"
+	   upstream_point="2011"
+       upstream_status="succeeded"
    }
    ...
 

--- a/src/user-guide/writing-workflows/external-triggers.rst
+++ b/src/user-guide/writing-workflows/external-triggers.rst
@@ -170,8 +170,8 @@ this:
        'task': task_name,
        'point': cycle_point,
        'status': task_status,  # or
-	   'trigger': task_output_trigger,  # or
-	   'message': task_output_message,
+       'trigger': task_output_trigger,  # or
+       'message': task_output_message,
        'flow_num': flow_num  # if given
    }
    return (satisfied, results)
@@ -193,8 +193,8 @@ To see this, take a look at the job script for one of the downstream tasks:
        export upstream_workflow upstream_cylc_run_dir upstream_offset \
          upstream_message upstream_status upstream_point upstream_task
        upstream_workflow="up"
-	   upstream_task="foo"
-	   upstream_point="2011"
+       upstream_task="foo"
+       upstream_point="2011"
        upstream_status="succeeded"
    }
    ...
@@ -398,7 +398,6 @@ success. The function signature is:
 .. automodule:: cylc.flow.xtriggers.xrandom
    :members: xrandom, validate
    :member-order: bysource
-   :noindex:
 
 An example xrandom trigger workflow:
 

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -538,7 +538,7 @@ In the following example, tasks ``bad`` and ``flaky`` each have 3 retries
 configured, with a 10 second delay between. On the final try, ``bad`` fails
 again and goes to the ``failed`` state, while ``flaky`` succeeds and triggers
 task ``whizz`` downstream. The scheduler will then stall because
-``bad`` finished with incomplete outputs.
+``bad`` failed (which is a :term:`final status`) with incomplete outputs.
 
 .. code-block:: cylc
 

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -537,8 +537,8 @@ with a clock-trigger configured with the next retry delay.
 In the following example, tasks ``bad`` and ``flaky`` each have 3 retries
 configured, with a 10 second delay between. On the final try, ``bad`` fails
 again and goes to the ``failed`` state, while ``flaky`` succeeds and triggers
-task ``whizz`` downstream. The scheduler will then stall with
-``bad`` retained as an incomplete task.
+task ``whizz`` downstream. The scheduler will then stall because
+``bad`` finished with incomplete outputs.
 
 .. code-block:: cylc
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1494,26 +1494,36 @@ to the task cycle point.
 Clock-Expire Triggers
 ^^^^^^^^^^^^^^^^^^^^^
 
-Tasks can be configured to *expire* and skip job submission if they are too far
-behind the wallclock when they become ready to run (and other tasks can trigger
-off of this).
+Tasks can be configured to :term:`expire <expired task>` if the wall clock
+time exceeds some offset from their cycle point.
 
-For example, if a clock-triggered task always copies the latest of a set of
-files to overwrite the previous set, in every cycle, there would be no point in
-running it late because the files it copied would be immediately overwritten by
-the next task instance as the workflow catches back up to real time operation.
 
-Clock-expire tasks are configured with
+The associated ``:expire`` :term:`output <task output>` can be used to
+trigger other tasks. It must be marked as an :term:`optional output`,
+i.e. expiry cannot be :term:`required <required output>`.
+
+Family triggers are also provided for task expiry:
+
+.. code-block:: cylc-graph
+
+   R1 = """
+      foo:expire? => bar
+      FAM:expire-all? => baz
+      FAM:expire-any? => qux
+   """
+
+Task expiration is configured with
 :cylc:conf:`[scheduling][special tasks]clock-expire` using a syntax like
 :cylc:conf:`clock-trigger <[scheduling][special tasks]clock-trigger>`
 with a datetime offset relative to cycle point.
+
 The offset should be positive to make the task expire if the wallclock time
 has gone beyond the cycle point.
 
 .. warning::
 
-   The scheduler can only determine that a task has expired once it has
-   appeared in the active window of the workflow.
+   The scheduler can only determine that a task has expired once it
+   enters the :term:`n=0 window <n-window>`.
 
 
 .. _WorkflowConfigExternalTriggers:
@@ -1528,27 +1538,31 @@ in :ref:`Section External Triggers`.
 
 .. _User Guide Required Outputs:
 .. _required outputs:
-.. _incomplete tasks:
 
 Required Outputs
 ----------------
 
 .. versionadded:: 8.0.0
 
-:term:`Task outputs <task output>` in the :term:`graph` are either
-:term:`required <required output>` (the default) or  :term:`optional <optional
-output>`.
+:term:`Task outputs <task output>` in the :term:`graph` can be
+:term:`required <required output>` (the default) or
+:term:`optional <optional output>` (marked with ``?`` in the graph).
 
-The scheduler requires all task outputs to be completed at runtime, unless they
-are marked with ``?`` as optional. This allows it to correctly diagnose
+Tasks are expected to complete required outputs at runtime, but
+they can finish without completing optional outputs.
+
+This allows the scheduler to correctly diagnose
 :term:`workflow completion`. [2]_
 
-Tasks that finish without completing required outputs  [3]_ are retained as
-:ref:`incomplete <incomplete tasks>` pending user intervention, e.g. to be
-retriggered after a bug fix.
+Tasks that :term:`finish <finished task>` without completing their
+outputs [3]_ are retained in the :term:`n=0 window <n-window>` pending user
+intervention, e.g. to be retriggered after a bug fix.
 
 .. note::
-   Incomplete tasks stall the workflow if there is nothing else to do (see
+   Tasks that finish without completing their outputs will raise a warning
+   and stall the workflow when there is nothing else for the scheduler to
+   run. to do (see
+
    :ref:`workflow completion`). They also count toward the :term:`runahead
    limit`, because they may run again once dealt with.
 
@@ -1559,8 +1573,9 @@ This graph says task ``bar`` should trigger if ``foo`` succeeds:
    foo => bar  # short for "foo:succeed => bar"
 
 Additionally, ``foo`` is required to succeed, because its success is not marked
-as optional. If ``foo`` does not succeeded, the scheduler will not run ``bar``,
-and ``foo`` will be retained as an incomplete task.
+as optional. If ``foo`` :term:`finishes <finished task>` without succeeding the
+scheduler will not run ``bar``, and ``foo`` will be retained
+in :term:`n=0 <n-window>` pending user intervention.
 
 Here, ``foo:succeed``, ``bar:x``, and ``baz:fail`` are all required outputs:
 
@@ -1607,8 +1622,9 @@ trigger if ``foo`` succeeds:
 
    foo? => bar  # short for "foo:succeed? => bar"
 
-But now ``foo:succeed`` is optional, so we might expect it to fail sometimes.
-And if it does fail, it will not be marked as an incomplete task.
+But now ``foo:succeed`` is optional so we might expect it to fail sometimes.
+And if it does fail, it will not be retained in the
+:term:`n=0 window <n-window>` as incomplete.
 
 Here, ``foo:succeed``, ``bar:x``, and ``baz:fail`` are all optional outputs:
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1549,22 +1549,20 @@ Required Outputs
 :term:`optional <optional output>` (marked with ``?`` in the graph).
 
 Tasks are expected to complete required outputs at runtime, but
-they can finish without completing optional outputs.
+they don't have to complete optional outputs.
 
 This allows the scheduler to correctly diagnose
 :term:`workflow completion`. [2]_
 
-Tasks that :term:`finish <finished task>` without completing their
+Tasks that achieve a :term:`final status` without completing their
 outputs [3]_ are retained in the :term:`n=0 window <n-window>` pending user
 intervention, e.g. to be retriggered after a bug fix.
 
 .. note::
-   Tasks that finish without completing their outputs will raise a warning
-   and stall the workflow when there is nothing else for the scheduler to
-   run. to do (see
-
-   :ref:`workflow completion`). They also count toward the :term:`runahead
-   limit`, because they may run again once dealt with.
+   Tasks that achieve a final status without completing their outputs will
+   raise a warning and stall the workflow when there is nothing else for
+   the scheduler to run (see :ref:`workflow completion`). They also count
+   toward the :term:`runahead limit`, because they may run again once dealt with.
 
 This graph says task ``bar`` should trigger if ``foo`` succeeds:
 
@@ -1573,7 +1571,7 @@ This graph says task ``bar`` should trigger if ``foo`` succeeds:
    foo => bar  # short for "foo:succeed => bar"
 
 Additionally, ``foo`` is required to succeed, because its success is not marked
-as optional. If ``foo`` :term:`finishes <finished task>` without succeeding the
+as optional. If ``foo`` achieves a :term:`final status` without succeeding the
 scheduler will not run ``bar``, and ``foo`` will be retained
 in :term:`n=0 <n-window>` pending user intervention.
 
@@ -1676,7 +1674,8 @@ following graph, ``foo`` is required to succeed, but it doesn't matter whether
 .. note::
 
    Optional outputs do not affect *triggering*. They just tell the scheduler
-   what to do with the task if it finishes without completing the output.
+   what to do with the task if it reaches a :term:`final status` without
+   completing the output.
 
    This graph triggers ``bar`` if ``foo`` succeeds, and does not trigger
    ``bar`` if ``foo`` fails:

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1506,11 +1506,9 @@ Family triggers are also provided for task expiry:
 
 .. code-block:: cylc-graph
 
-   R1 = """
-      foo:expire? => bar
-      FAM:expire-all? => baz
-      FAM:expire-any? => qux
-   """
+   foo:expire? => bar
+   FAM:expire-all? => baz
+   FAM:expire-any? => qux
 
 Task expiration is configured with
 :cylc:conf:`[scheduling][special tasks]clock-expire` using a syntax like
@@ -1707,16 +1705,12 @@ is optional" and that a non-optional version of the trigger makes sense.
 .. code-block:: cylc-graph
 
    # Good:
-   R1 = """
-      foo:finish => bar
-      foo? => baz
-   """
+   foo:finish => bar
+   foo? => baz
 
    # Error:
-   R1 = """
-      foo:finish => bar
-      foo => baz  # ERROR : foo:succeed must be optional here!
-   """
+   foo:finish => bar
+   foo => baz  # ERROR : foo:succeed must be optional here!
 
 .. _optional outputs.family triggers:
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1560,7 +1560,7 @@ intervention, e.g. to be retriggered after a bug fix.
    Tasks that achieve a final status without completing their outputs will
    raise a warning and stall the workflow when there is nothing else for
    the scheduler to run (see :ref:`workflow completion`). They also count
-   toward the :term:`runahead limit`, because they may run again once dealt with.
+   toward the :term:`runahead limit`.
 
 This graph says task ``bar`` should trigger if ``foo`` succeeds:
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -2092,7 +2092,7 @@ E.G. for this example workflow:
         [[graph]]
             P1 = foo
 
-When this workflow starts, the initial cycle point is 1 and the runahad limit
+When this workflow starts, the initial cycle point is 1 and the runahead limit
 is four cycles after this (i.e. cycle 4). So the task ``foo`` will immediately
 submit in cycles 1, 2, 3 and 4, however, the tasks in cycles 5 onwards will
 wait until earlier cycles complete, and the runahead limit advances.

--- a/src/workflows/xtrigger/sequential/flow.cylc
+++ b/src/workflows/xtrigger/sequential/flow.cylc
@@ -4,8 +4,7 @@
     initial cycle point = 2010
     sequential xtriggers = True
     [[xtriggers]]
-         upstream = workflow_state(workflow=up, task=foo, point=%(point)s, \
-            message='data ready'):PT10S
+         upstream = workflow_state(up//%(point)s/foo:x):PT10S
          clock_0 = wall_clock(offset=PT0H, sequential=False)
    [[graph]]
         P1Y = """

--- a/src/workflows/xtrigger/sequential/flow.cylc
+++ b/src/workflows/xtrigger/sequential/flow.cylc
@@ -4,7 +4,7 @@
     initial cycle point = 2010
     sequential xtriggers = True
     [[xtriggers]]
-         upstream = workflow_state(up//%(point)s/foo:x):PT10S
+         upstream = workflow_state("up//%(point)s/foo:x"):PT10S
          clock_0 = wall_clock(offset=PT0H, sequential=False)
    [[graph]]
         P1Y = """

--- a/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
+++ b/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
@@ -3,8 +3,7 @@
 [scheduling]
     initial cycle point = 2010
     [[xtriggers]]
-         upstream = workflow_state(workflow=up, task=foo, point=%(point)s, \
-            message='data ready'):PT10S
+         upstream = workflow_state(up//%(point)s/foo:x):PT10S
          clock_0 = wall_clock(offset=PT0H)
    [[graph]]
         P1Y = """

--- a/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
+++ b/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
@@ -3,7 +3,7 @@
 [scheduling]
     initial cycle point = 2010
     [[xtriggers]]
-         upstream = workflow_state(up//%(point)s/foo:x):PT10S
+         upstream = workflow_state("up//%(point)s/foo:x"):PT10S
          clock_0 = wall_clock(offset=PT0H)
    [[graph]]
         P1Y = """


### PR DESCRIPTION
A quick blast through the docs (mostly the glossary) whilst trying not to overlap too much with the optional-outputs-extension, which should be documented separately (mostly by pasting from the proposal).

(I did add a glossary item on output completion, needed for cross-referencing).


### note on "incomplete"

We agreed not to define an "incomplete task" as **a finished task with incomplete outputs** (because that made "incomplete" different to "not complete" ). 

Now, "completion" is tied entirely to "output completion". That means it is legit to say that a task is incomplete if its outputs are incomplete, whether or not it has finished. That's convenient and I've used it a couple of times here. E.g. it means we can say a stall occurs if there is nothing left to run but *there are any incomplete tasks in the n=0 window" - that covers both finished-with-incomplete-outputs and waiting-with-partially-satisfied-prerequisites. Both of those are "active tasks" (i.e., in n=0) and have incomplete outputs.




**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
