### PR TITLE
Add warning about interactive guard clause in some default .bashrc files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ requests_).
  - David Sutherland
  - Thomas Coleman
  - Scott Wales
+ - Elliot Fontaine
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/src/user-guide/troubleshooting.rst
+++ b/src/user-guide/troubleshooting.rst
@@ -93,6 +93,16 @@ run for interactive sessions like so:
    export PATH="$HOME/bin:$PATH"
    export MY_LIB_PATH="$HOME/my-lib/1.0/"
 
+Conversely, make sure to **remove** the interactive guard clause that is present in the default ``.bashrc`` of some Linux distributions (e.g. `Debian <https://sources.debian.org/src/bash/4.3-11/debian/skel.bashrc/>`_).
+
+.. code-block:: bash
+
+   # If not running interactively, don't do anything
+   case $- in
+       *i*) ;;
+         *) return;;
+   esac
+
 Some things to check your login files for:
 
 * Don't write to stdout (e.g. using ``echo`` or ``printf``), this can interfere


### PR DESCRIPTION
**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

See [this forum thread](https://cylc.discourse.group/t/conda-command-not-found-inside-workflow-task/962/3).