### PR TITLE
Set maxdepth for examples toctree to 1 to prevent sub-headings showin…

### DIFF
--- a/src/user-guide/examples/index.rst
+++ b/src/user-guide/examples/index.rst
@@ -6,6 +6,7 @@ Examples
 These examples cover some of the main patterns for implementing Cylc workflows.
 
 .. toctree::
+   :maxdepth: 1
    :glob:
 
    */index


### PR DESCRIPTION
…g up.

Came out of reviewing https://github.com/cylc/cylc-flow/pull/6223/files - I don't think seeing the "example" heading you used halfway down that PR is terribly helpful in the overall examples toctree.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
