### PR TITLE
whilst -> while

### DIFF
--- a/src/tutorial/furthertopics/broadcast.rst
+++ b/src/tutorial/furthertopics/broadcast.rst
@@ -11,7 +11,7 @@ running workflow, on-the-fly.
 Purpose
 -------
 
-``cylc broadcast`` can be used to change any ``[runtime]`` setting whilst the
+``cylc broadcast`` can be used to change any ``[runtime]`` setting while the
 workflow is running.
 
 The standard use of ``cylc broadcast`` is to update the workflow to an
@@ -57,7 +57,7 @@ the log entry will look like this::
    10120101T0000Z - We are the knights who say "ni"!
 
 The ``cylc broadcast`` command enables us to change runtime configuration
-whilst the workflow is running. For instance we could change the value of the
+while the workflow is running. For instance we could change the value of the
 ``WORD`` environment variable using the command::
 
    cylc broadcast tutorial-broadcast -n announce -s "[environment]WORD=it"

--- a/src/tutorial/furthertopics/message-triggers.rst
+++ b/src/tutorial/furthertopics/message-triggers.rst
@@ -20,7 +20,7 @@ Usage
 -----
 
 :term:`Message triggers <message trigger>` are particularly useful if we have
-a long running task and we want to produce multiple tailored outputs whilst
+a long running task and we want to produce multiple tailored outputs while
 this task is running, rather than having to wait for the task to
 complete.
 

--- a/src/user-guide/cheat-sheet.rst
+++ b/src/user-guide/cheat-sheet.rst
@@ -131,7 +131,7 @@ First, make your required changes to the files in the workflow's
    # validate, reinstall and reload the workflow
    cylc vr <id>
 
-If you want to quickly edit a task's configuration, e.g. whilst developing a
+If you want to quickly edit a task's configuration, e.g. while developing a
 workflow or testing changes, the 
 :ref:`"Edit Runtime" feature <interventions.edit-a-tasks-configuration>`
 in the GUI can be convenient.

--- a/src/user-guide/interventions/index.rst
+++ b/src/user-guide/interventions/index.rst
@@ -5,7 +5,7 @@ Interventions
 
 Sometimes things don't go to plan!
 
-So Cylc allows you to take manual control of your workflow whilst it's running
+So Cylc allows you to take manual control of your workflow while it's running
 allowing you to do things like edit a task's configuration, re-run a section
 of your graph or override task outputs.
 
@@ -445,7 +445,7 @@ Hold The Workflow And Trigger Tasks One By One
 ----------------------------------------------
 
 :Example:
-   I want to hold back the workflow whilst I manually run one or more tasks
+   I want to hold back the workflow while I manually run one or more tasks
    to fix a problem or test a task.
 
 :Solution:

--- a/src/user-guide/task-implementation/job-submission.rst
+++ b/src/user-guide/task-implementation/job-submission.rst
@@ -220,7 +220,7 @@ Any tasks recorded in the *submitted* or *running* states at workflow
 restart are automatically polled to determine what happened to them while the
 workflow was down.
 
-By default, regular polling also takes place every 15 minutes whilst a job is
+By default, regular polling also takes place every 15 minutes while a job is
 submitted or running. The default polling intervals can be overridden in the
 global configuration:
 


### PR DESCRIPTION
As flagged in Element chat, "whilst" is entirely equivalent to "while" in all uses here, but "whilst" sticks out as old-fashioned to many readers. We mostly use "while" in the docs, but a few "whilst"s have crept in.

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
