### PR TITLE
fix broken link

### DIFF
--- a/src/installation.rst
+++ b/src/installation.rst
@@ -117,7 +117,7 @@ Installing On Mac OS
 --------------------
 
 .. _Homebrew: https://formulae.brew.sh/
-.. _atrun: https://www.unix.com/man-page/FreeBSD/8/atrun/
+.. _atrun: https://man.freebsd.org/cgi/man.cgi?query=atrun&sektion=8&format=html
 
 Cylc requires some extra packages to function on Mac OS. We recommend
 installing them using the `Homebrew`_ package manager:


### PR DESCRIPTION
The man pages for FreeBSD on unix.com now redirect the community.unix.com?!

Found an alternative man page.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
