### PR TITLE
Add to dictionary

### DIFF
--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -55,6 +55,7 @@ gscan
 hardcodes
 hardwired
 hardwiring
+heathrow
 heredocs
 hetjob
 hostname
@@ -75,6 +76,7 @@ iso
 iterable
 jitter
 jobscript
+json
 kwarg
 kwargs
 latin


### PR DESCRIPTION
Spellcheck seems to be flagging a couple of words all of a sudden?!

Dunno, see this GH actions output: https://github.com/cylc/cylc-doc/actions/runs/12050889159/job/33600712776?pr=780#step:10:752

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
