### PR TITLE
fix build error

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -134,6 +134,8 @@ intersphinx_mapping = {
 }
 
 nitpick_ignore = [
+    # external deps we don't cross-link to
+    ('py:class', 'zmq.auth.thread.ThreadAuthenticator'),
     # This class appears in documented type-hints but is not documented in the
     # Python docs so fails build.
     ('py:class', 're.Pattern'),

--- a/src/reference/changes.rst
+++ b/src/reference/changes.rst
@@ -400,7 +400,7 @@ Cylc 8.1
 .. admonition:: Cylc Components
    :class: hint
 
-   :cylc-flow: `8.1 <https://github.com/cylc/cylc-flow/blob/8.1.x/CHANGES.md>`__
+   :cylc-flow: `8.1 <https://github.com/cylc/cylc-flow/blob/master/CHANGES.md#cylc-814-released-2023-05-04>`__
    :cylc-uiserver: `1.2 <https://github.com/cylc/cylc-uiserver/blob/1.2.x/CHANGES.md>`__
    :cylc-rose: `1.1 <https://github.com/cylc/cylc-rose/blob/1.1.0/CHANGES.md#user-content-cylc-rose-110-released-2022-07-28>`__
 


### PR DESCRIPTION
* Sphinx tries to cross-link typing information.
* If it can't find a type to link to, it will fail in nit-pick mode.
* If we don't want it to fail, we must list the references in an ignore section.

Example failure: https://github.com/cylc/cylc-doc/actions/runs/13381697432/job/37371236269

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
