### PR TITLE
Fix example workflow_state xtrigger args.

### DIFF
--- a/src/workflows/xtrigger/sequential/flow.cylc
+++ b/src/workflows/xtrigger/sequential/flow.cylc
@@ -4,7 +4,7 @@
     initial cycle point = 2010
     sequential xtriggers = True
     [[xtriggers]]
-         upstream = workflow_state("up//%(point)s/foo:x"):PT10S
+         upstream = workflow_state("up//%(point)s/foo:x", is_trigger=True):PT10S
          clock_0 = wall_clock(offset=PT0H, sequential=False)
    [[graph]]
         P1Y = """

--- a/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
+++ b/src/workflows/xtrigger/workflow_state/downstream/flow.cylc
@@ -3,7 +3,7 @@
 [scheduling]
     initial cycle point = 2010
     [[xtriggers]]
-         upstream = workflow_state("up//%(point)s/foo:x"):PT10S
+         upstream = workflow_state("up//%(point)s/foo:x", is_trigger=True):PT10S
          clock_0 = wall_clock(offset=PT0H)
    [[graph]]
         P1Y = """


### PR DESCRIPTION
Fix [doc bug revealed on the forum](https://cylc.discourse.group/t/external-triggers-not-working-with-workflow-state-function/1143/2)

One review will do.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
