### PR TITLE
retries: consolidate and improve docs

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -55,6 +55,7 @@ Glossary
 
       .. seealso::
 
+         * :ref:`Tutorial <tutorial.retries>`
          * :ref:`Cylc User Guide <TaskRetries>`
 
 

--- a/src/tutorial/furthertopics/retries.rst
+++ b/src/tutorial/furthertopics/retries.rst
@@ -1,5 +1,11 @@
+.. _tutorial.retries:
+
 Retries
 =======
+
+.. seealso::
+
+   :ref:`Cylc User Guide <TaskRetries>`
 
 Retries allow us to automatically re-submit tasks which have failed due to
 failure in submission or execution.
@@ -102,13 +108,16 @@ This means that if the ``roll_doubles`` task fails, Cylc expects to
 retry running it 5 times before finally failing. Each retry will have
 a delay of 6 seconds.
 
-We can apply multiple retry periods with the ``execution retry delays`` setting
-by separating them with commas, for example the following line would tell Cylc
-to retry a task four times, once after 15 seconds, then once after 10 minutes,
-then once after one hour then once after three hours.
+We can apply multiple retry periods with the
+`execution retry delays <[runtime][<namespace>]execution retry delays>` setting
+by separating them with commas, e.g:
 
 .. code-block:: cylc
 
+   # If the task fails, wait 15 seconss, then retry it.
+   # If the retry fails, wait a further 10 minutes, then retry it again.
+   # If the second retry fails, wait a further 1 hour, then retry it again.
+   # If the third retry fails, wait a further 3 hours, then retry it again.
    execution retry delays = PT15S, PT10M, PT1H, PT3H
 
 
@@ -158,4 +167,6 @@ This time, the task should definitely succeed before the third retry.
 Further Reading
 ---------------
 
-For more information see the `Cylc User Guide`_.
+* :ref:`Cylc User Guide <TaskRetries>`
+* `[runtime][<namespace>]execution retry delays`.
+* `[runtime][<namespace>]submission retry delays`.

--- a/src/tutorial/runtime/runtime-configuration.rst
+++ b/src/tutorial/runtime/runtime-configuration.rst
@@ -186,6 +186,11 @@ Jobs can fail for several reasons:
    left. Otherwise they return to the waiting state, to wait on the next try.
 
 
+.. seealso::
+
+   * :ref:`Tutorial <tutorial.retries>`.
+   * :ref:`User Guide <TaskRetries>`.
+
 
 .. _tutorial.start_stop_restart:
 

--- a/src/user-guide/running-workflows/index.rst
+++ b/src/user-guide/running-workflows/index.rst
@@ -8,7 +8,6 @@ Running Workflows
 
    scheduler-start-up
    tasks-jobs-ui
-   retrying-tasks
    tracking-task-state
    workflow-completion
    reflow

--- a/src/user-guide/running-workflows/retrying-tasks.rst
+++ b/src/user-guide/running-workflows/retrying-tasks.rst
@@ -1,51 +1,6 @@
+:orphan:
+
 Retrying Tasks
 ==============
 
-.. versionchanged:: 8.0.0
-
-Tasks that fail but are configured to :term:`retry` return to the ``waiting``
-state, with a new clock trigger to handle the configured retry delay.
-
-.. note::
-
-   A task that is waiting on a retry will already have one or more failed jobs
-   associated with it.
-
-
-.. note::
-
-   Tasks only enter the ``submit-failed`` state if job submission fails with no
-   retries left. Otherwise they return to the waiting state, to wait on the
-   next try.
-
-   Tasks only enter the ``failed`` state if job execution fails with no retries
-   left. Otherwise they return to the waiting state, to wait on the next try.
-
-
-
-Aborting a Retry Sequence
--------------------------
-
-To prevent a task from retrying, remove it from the scheduler's
-:term:`active window`. For a task ``3/foo`` in workflow ``brew``:
-
-.. code-block:: console
-
-   $ cylc remove brew//3/foo
-
-If you *kill* a running task that has more retries configured, it goes to the
-``held`` state so you can decide whether to release it and continue the retry
-sequence, or remove it.
-
-.. code-block:: console
-
-   $ cylc kill brew//3/foo     # 3/foo goes to held state post kill
-   $ cylc release brew//3/foo  # release to continue retrying...
-   $ cylc remove brew//3/foo   # ... OR remove the task to stop retries
-
-
-If you want trigger downstream tasks despite ``3/foo`` being removed before it
-could succeed, use ``cylc set`` to artificially mark its
-:term:`required outputs <required output>`
-as complete (and with the ``--flow`` option, if needed to make a specific
-:term:`flow` continue on from there).
+This section has moved to :ref:`TaskRetries`.


### PR DESCRIPTION
* Closes #570
* Merge the writing and running docs on retries to prevent sprawl (leave the old page in as a redirect).
* Clarify that retry delays are incremental.
* Add missing information about task events and triggers.
* Better inter-link the docs.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
