### PR TITLE
Disambiguate the word "active".

### DIFF
--- a/src/7-to-8/major-changes/scheduling.rst
+++ b/src/7-to-8/major-changes/scheduling.rst
@@ -23,21 +23,21 @@ Cylc can manage infinite workflows of repeating tasks:
 
 Cylc 8 has a new scheduling algorithm that:
 
-- Is much more efficient because it only has to manage active tasks
+- Is much more efficient because it only has to manage :term:`active tasks`.
 
-  - waiting tasks are not pre-spawned before they are needed
-  - succeeded tasks are not kept across the active task window
-  - no costly indiscriminate dependency matching is done
+  - Tasks are not "pre-spawned" before they are needed.
+  - Tasks are not retained in memory once they complete.
+  - There is no costly indiscriminate dependency matching.
 - Distinguishes between :term:`optional <optional output>` and
   :term:`required <required output>` task outputs, to support:
 
   - :term:`graph branching` without :term:`suicide triggers <suicide trigger>`
-  - correct diagnosis of :term:`workflow completion`
+  - correct diagnosis of :ref:`workflow completion`
 - Causes no implicit dependence on previous-instance job submit
 
   - instances of same task can run out of cycle point order
   - the workflow will not unnecessarily stall downstream of failed tasks
-- Provides a sensible active-task based window on the evolving workflow
+- Provides a sensible activity-based window on the evolving workflow
 
   - (to fully understand which tasks appeared in the Cylc 7 GUI you had to
     understand the scheduling algorithm)

--- a/src/7-to-8/major-changes/scheduling.rst
+++ b/src/7-to-8/major-changes/scheduling.rst
@@ -25,7 +25,7 @@ Cylc 8 has a new scheduling algorithm that:
 
 - Is much more efficient because it only has to manage :term:`active tasks`.
 
-  - Tasks are not "pre-spawned" before they are needed.
+  - Tasks are not loaded into memory before they are needed.
   - Tasks are not retained in memory once they complete.
   - There is no costly indiscriminate dependency matching.
 - Distinguishes between :term:`optional <optional output>` and

--- a/src/7-to-8/major-changes/scheduling.rst
+++ b/src/7-to-8/major-changes/scheduling.rst
@@ -23,7 +23,8 @@ Cylc can manage infinite workflows of repeating tasks:
 
 Cylc 8 has a new scheduling algorithm that:
 
-- Is much more efficient because it only has to manage :term:`active tasks`.
+- Is much more efficient because it only has to manage
+  :term:`active tasks <active task>`.
 
   - Tasks are not loaded into memory before they are needed.
   - Tasks are not retained in memory once they complete.

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -134,7 +134,7 @@ intervention, which will :term:`stall` the workflow.
 Alternatively, outputs can be marked as :term:`optional <optional output>`,
 which allows :term:`optional graph branching <graph branching>`.
 
-This allows the scheduler to correctly diagnose :term:`workflow completion`.
+This allows the scheduler to correctly diagnose :ref:`workflow completion`.
 
 
 Platform Awareness

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -68,50 +68,36 @@ Glossary
       Submit number also appears in the job log path so that job log files
       don't get overwritten.
 
-
-   active
    active task
-      An active task is a task which is near ready to run, in the process of
-      running, or which requires user intervention. These are all the tasks
-      being actively managed by the scheduler at this point in the run. 
+      Active tasks are those tasks currently held in working memory to feed
+      the scheduling algorithm. They comprise ``n=0`` basis of the GUI
+      :term:`n-window`, so they are always visible in the GUI.
 
-      Active tasks are:
+      Active tasks include:
 
-      - Tasks which have some, but not all of their
-        :term:`prerequisites <prerequisite>` satisfied.
-      - ``waiting`` tasks, that are actively waiting on:
+      - ``submitted`` and ``running``, with active jobs)
+      - ``preparing`` tasks in the job submission pipeline
+      - ``waiting`` tasks that are nearly ready to run but:
 
-        - :term:`xtriggers <xtrigger>`.
-        - :ref:`internal queues <InternalQueues>`
-        - :ref:`runahead limit <RunaheadLimit>`
+        - have partially satisfied :term:`prerequisites <prerequisite>`
+        - or are waiting on :term:`xtriggers <xtrigger>`,
+          :ref:`internal queues <InternalQueues>`, or the :ref:`runahead limit <RunaheadLimit>`
 
-      - ``preparing`` tasks - i.e. tasks in the process of submitting jobs
-      - ``submitted`` and ``running`` tasks - i.e. those with active jobs
       - tasks that reached a :term:`final status` without completing their
         :term:`required outputs <required output>`
         (e.g. a task failed where success was required).
 
-      Active tasks are in the ``n=0`` :term:`window <n-window>` which means they
-      will always be displayed in the GUI and Tui.
 
-      The distinction between active and non-active tasks is important for
-      the computing of the :term:`runahead limit`.
-
+   n-window
+      The GUI provides a view of the workflow extending ``n`` graph edges out
+      from :term:`active tasks <active task>` - which comprise the ``n=0``
+      window. The default n-window extent is ``n=1``. 
 
    active cycle
-      A cycle point is active if it contains any :term:`active tasks <active task>`.
-
-      Active cycles are counted towards the :term:`runahead limit`.
-
-
-   window
-   n-window
-   active window
-      The GUI provides a :term:`graph`-based window or view of the workflow at
-      runtime, including tasks out to ``n`` graph edges from current
+      A cycle point is considered to be active if it contains any
       :term:`active tasks <active task>`.
 
-      Active tasks form the ``n=0`` window.
+     Active cycles count toward the :term:`runahead limit`.
 
       .. seealso::
 
@@ -381,6 +367,9 @@ Glossary
       ``3``, etc.
       For :term:`datetime cycling` they will be :term:`ISO 8601` datetimes,
       e.g. ``2000-01-01T00:00Z``.
+
+      Cylc has no global cycle loop, so each task instance has its own cycle
+      point label.
 
       .. seealso::
 
@@ -993,7 +982,7 @@ Glossary
       This refers to starting a new instance of the Cylc :term:`scheduler`
       program to manage a particular :term:`workflow`. This can be from
       scratch, for installed workflows that haven't run previously, or to
-      restart one that shut down prior to :term:`completion <workflow completion>`.
+      restart one that shut down prior to :ref:`completion <workflow completion>`.
 
       .. seealso::
 
@@ -1170,7 +1159,7 @@ Glossary
    stop
    shutdown
       A :term:`scheduler` can shut down on request, or automatically on
-      :term:`workflow completion`. The :term:`workflow` is then stopped and no
+      :ref:`workflow completion`. The :term:`workflow` is then stopped and no
       further :term:`jobs <job>` will be submitted.
 
       By default, the scheduler waits for any submitted or running task
@@ -1216,9 +1205,10 @@ Glossary
       workflow :term:`source directory` before reload, rather than made by
       editing the installed files directly.
 
-      :ref:`RemoteInit` will be redone for each job platform, when the first job is submitted there after a reload.
+      :ref:`RemoteInit` will be redone for each job platform, when the first
+      job is submitted there after a reload.
 
-      Any :term:`task` that is :term:`active <active task>` at reload
+      Any task that is :term:`active <active task>` at reload
       will continue with its pre-reload configuration.
       The next instance of the task (at the next cycle point)
       will adopt the new configuration.
@@ -1433,7 +1423,7 @@ Glossary
       - Or, if expiry is optional, then the outputs are complete if it expires.
 
       Tasks that achieve a :term:`final status` with complete outputs have done
-      their job, allowing the workflow to move on.
+      their job in the workflow, allowing the scheduler to move on.
 
       Tasks that achieve a final status with incomplete outputs are retained in
       :term:`n=0 <n-window>` pending user intervention, and will :term:`stall`
@@ -1587,7 +1577,7 @@ Glossary
 
    stall
    stalled workflow
-      A stalled workflow has not run to :term:`completion <workflow completion>`
+      A stalled workflow has not :ref:`run to completion <workflow completion>`
       but cannot continue without manual intervention. 
 
       A stalled scheduler stays alive for a configurable timeout period
@@ -1613,8 +1603,7 @@ Glossary
 
 
    suicide trigger
-      Suicide triggers remove :term:`tasks <task>` from the 
-      :term:`active window <n-window>` at runtime.
+      Suicide triggers remove tasks from the :term:`n=0 window <n-window>`.
 
       They are denoted by exclamation marks, and are triggered like normal
       dependencies. For instance, the following suicide trigger will remove the
@@ -1702,16 +1691,14 @@ Glossary
 
 
    flow front
-      :term:`Active tasks <active task>`, i.e. tasks in the
-      :term:`n=0 window <n-window>`, with a common :term:`flow number`
+      :term:`Active tasks <active task>`` with a common :term:`flow number`
       comprise the active front of the flow.
 
 
    flow merge
-      When a :term:`flow` tries to spawn a child task and finds an instance
-      with the same task ID already exists in the ``n=0`` :term:`active
-      window`, one merged task will carry both flow numbers forward.
-
+      If a spawned task encounters another :term:`active task` with the same
+      task ID, the two instances will merge and carry both :term:`flow`
+      numbers forward.
 
    event
       An event is a milestone in the lifecycle of a :term:`workflow` or
@@ -1747,12 +1734,9 @@ Glossary
 
    runahead limit
    runahead
-      In a :term:`cycling workflow`, the runahead limit determines how far
-      ahead of the oldest :term:`active cycle` the workflow is permitted
-      to run.
-
-      The "oldest active cycle point" is the first cycle in the workflow to contain
-      any :term:`active tasks <active task>` (e.g. running tasks).
+      In a :term:`cycling workflow` the runahead limit determines how
+      far ahead, in :term:`cycle points <cycle point>`, activity can 
+      extend beyond the earliest submitted or running tasks.
 
       .. seealso::
 
@@ -1761,25 +1745,11 @@ Glossary
          * :term:`active cycle`
 
 
-   workflow completion
-      A workflow is complete, and the scheduler will automatically
-      :term:`shut down <shutdown>`, if no tasks remain in the
-      :term:`n=0 <n-window>`.
-
-      That is, all active tasks have finished, and no tasks remain waiting on
-      :term:`prerequisites <prerequisite>` or "external" constraints (such as
-      :term:`xtriggers <xtrigger>` or task :term:`hold`).
-
-      If no active tasks remain and all external constraints are satisfied,
-      but the n=0 window contains tasks waiting with partially satisfied
-      :term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
-      :term:`incomplete outputs <output completion>`, then the workflow is
-      not complete and the scheduler will :term:`stall` pending manual intervention.
-
    dummy task
       A task which runs a trivially simple script such as ``sleep 1``,
       ``exit 0`` or ``true``, or which uses :ref:`task-run-modes.skip`
       to avoid running a script at all.
+
 
    dummy mode
       A workflow run mode that replaces all tasks with :term:`dummy tasks <dummy task>`.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -70,12 +70,12 @@ Glossary
 
    active task
       Active tasks are those tasks currently held in working memory to feed
-      the scheduling algorithm. They comprise ``n=0`` basis of the GUI
-      :term:`n-window`, so they are always visible in the GUI.
+      the scheduling algorithm. They form the ``n=0`` :term:`n-window`,
+      so are always visible in the GUI.
 
       Active tasks include:
 
-      - ``submitted`` and ``running``, with active jobs)
+      - ``submitted`` and ``running`` tasks (i.e, tasks with active jobs)
       - ``preparing`` tasks in the job submission pipeline
       - ``waiting`` tasks that are nearly ready to run but:
 
@@ -90,7 +90,7 @@ Glossary
 
    n-window
       The GUI provides a view of the workflow extending ``n`` graph edges out
-      from :term:`active tasks <active task>` - which comprise the ``n=0``
+      from :term:`active tasks <active task>` - which form the ``n=0``
       window. The default n-window extent is ``n=1``. 
 
    active cycle

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -982,7 +982,8 @@ Glossary
       This refers to starting a new instance of the Cylc :term:`scheduler`
       program to manage a particular :term:`workflow`. This can be from
       scratch, for installed workflows that haven't run previously, or to
-      restart one that shut down prior to :ref:`completion <workflow completion>`.
+      restart one that shut down prior to
+      :ref:`completion <workflow completion>`.
 
       .. seealso::
 
@@ -1691,7 +1692,7 @@ Glossary
 
 
    flow front
-      :term:`Active tasks <active task>`` with a common :term:`flow number`
+      :term:`Active tasks <active task>` with a common :term:`flow number`
       comprise the active front of the flow.
 
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -69,7 +69,7 @@ Glossary
       don't get overwritten.
 
    active task
-      Active tasks are those tasks currently held in working memory to feed
+      Active tasks are those tasks held in memory to feed
       the scheduling algorithm. They form the ``n=0`` :term:`n-window`,
       so are always visible in the GUI.
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -344,7 +344,6 @@ Glossary
          "1/bar" -> "2/bar" -> "3/bar"
 
 
-
       .. seealso::
 
          * :ref:`tutorial-integer-cycling`
@@ -362,14 +361,14 @@ Glossary
 
 
    cycle point
-      The unique label given to tasks that belong to a particular :term:`cycle`.
+      The label given to tasks that belong to a particular :term:`cycle`.
       For :term:`integer cycling` these will be integers, e.g. ``1``, ``2``,
       ``3``, etc.
       For :term:`datetime cycling` they will be :term:`ISO 8601` datetimes,
       e.g. ``2000-01-01T00:00Z``.
 
-      Cylc has no global cycle loop, so each task instance has its own cycle
-      point label.
+      Cylc can run multiple cycles at once, dependencies allowing, so each
+      task instance has its own cycle point label.
 
       .. seealso::
 

--- a/src/reference/changes.rst
+++ b/src/reference/changes.rst
@@ -245,17 +245,14 @@ N-Window selector in the GUI
 
 The :term:`n-window` determines how much of a workflow is visible in the GUI / Tui.
 
-The ``n=0`` window contains only the active tasks
-(i.e. queued, preparing, submitted or running tasks).
+You can change the n-window extent in the GUI with a toolbar button, to display
+more or less of the graph around current :term:`active tasks <active task>`.
+This affects all GUI views equally, not just the graph view.
 
-The ``n=1`` window, also contains tasks one "edge" out from active tasks
-(i.e. the tasks immediately upstream or downstream of active tasks).
+The ``n=0`` window contains only the active tasks.
 
-The ``n=2`` window, also contains tasks two "edges" out from active tasks,
-and so on.
-
-It is now possible to change the window extent in the GUI via a button in the
-toolbar allowing you to see tasks further back in the workflow's history.
+The ``n=1`` window displays tasks out to one graph edge around the active
+tasks; ``n=2`` out to two graph edges; and so on.
 
 .. image:: changes/gui-n-window-selector.gif
    :width: 100%
@@ -306,7 +303,7 @@ When a task achieves a final status, its outputs are validated against a "comple
 expression" to ensure that it has produced all of its
 :term:`required outputs <required output>`.
 If a task fails this validation check it is said to have "incomplete outputs"
-and will be retained in the :term:`active window` pending user intervention.
+and will be retained in the :term:`n=0 window <n-window>` pending user intervention.
 
 This completion expression is generated automatically from the graph.
 By default, tasks are expected to succeed, if you register any additional

--- a/src/user-guide/interventions/index.rst
+++ b/src/user-guide/interventions/index.rst
@@ -558,7 +558,8 @@ Remove Tasks
 
          The removed task will be greyed out but it might not
          disappear from view because the GUI displays all tasks
-         in a graph-based window around current active tasks.
+         in a graph-based :term:`n-window` surrounding current
+         :term:`active tasks <active task>`.
 
 
    .. tab-item:: CLI

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -26,8 +26,8 @@ See :ref:`below<flow-trigger-use-cases>` for uses, and an
 :ref:`example<new-flow-example>`, of concurrent flows.
 
 .. note::
-   Flows :ref:`merge<flow-merging>` where (and if) tasks collide in the ``n=0``
-   :term:`active window`. Downstream of a merge, tasks are considered to belong
+   Flows :ref:`merge<flow-merging>` where (and if) tasks collide in the
+   :term:`n=0 window <n-window>`. Downstream of a merge, tasks are considered to belong
    to all of their constituent flows.
 
 
@@ -92,7 +92,7 @@ Triggering in Specific Flows
 
    The result is like the default above, except that tasks in the new front
    belong only to the specified flow(s), regardless of which flows are
-   :term:`active` at triggering time.
+   active at triggering time.
 
 Triggering a New Flow
    ``cylc trigger --flow=new ID``
@@ -117,20 +117,21 @@ Triggering with No Active Flows
    ``cylc trigger [--wait] ID``
 
    By default, triggered tasks will be given the flow numbers of the most
-   recent active task. This can happen, for instance, if you restart a
-   completed workflow and then trigger a task in it. The result will be the
-   same as if you had triggered the task just before the workflow completed.
+   recent :term:`active tasks <active task>`. This can happen, for instance,
+   if you restart an already-completed workflow and then manually trigger a
+   task in it. The task's flow number will be the same as if you
+   had triggered it just before the workflow completed.
 
-Special Case: Triggering ``n=0`` Tasks
-   Tasks in the ``n=0`` window are :term:`active tasks <active task>`.
-   Their flow membership is already determined - that of
-   the parent tasks that spawned them.
+Special Case: Triggering ``n=0`` (:term:`active tasks <active task`)
+   Active tasks already have flow membership assigned.
+   Flow numbers are inherited, on entering the active wndow, from parent
+   (upstream) tasks in the graph.
 
    - Triggering a task with a submitted or running job has no effect
      (it is already triggered).
-   - Triggering other :term:`n=0 tasks <n-window>`, including tasks with
-     :term:`incomplete outputs <output completion>` queues them to run in
-     the flow that they already belong to.
+   - Triggering other :term:`active tasks <active task>`, including those with
+     :term:`incomplete outputs <output completion>`, queues them to run with
+     their existing flow numbers.
 
 
 .. _flow-merging:
@@ -142,8 +143,9 @@ If a task spawning into the :term:`n=0 window <n-window>` finds another instance
 of itself (same task ID) already there, the two will merge and carry both
 (sets of) flow numbers forward. Downstream tasks will belong to both flows.
 
-Flow merging is necessary because :term:`active <active task>` task IDs
-must be unique.
+Flows merge because every :term:`active task` must have a unique ID. However,
+merging is also useful: it allows a simpler single flow to continue downstream of
+multi-flow interventions.
 
 If the original task instance has a :term:`final status` (and has been retained
 in the :term:`n=0 window <n-window>` with
@@ -157,9 +159,9 @@ Stopping Flows
 By default, ``cylc stop`` halts the workflow and shuts the scheduler down.
 
 It can also stop specific flows: ``cylc stop --flow=N`` removes the flow number
-``N`` from :term:`active tasks <active task>`. Tasks that have no flow
-numbers left as a result do not spawn children at all. If there are no active
-flows left, the scheduler shuts down.
+``N`` from :term:`active tasks <active task>`. Tasks with no remaining flow
+numbers will not spawn downstream activity. If there are
+no active flows left, the scheduler shuts down.
 
 .. TODO update this section post https://github.com/cylc/cylc-flow/issues/4741
 

--- a/src/user-guide/running-workflows/reflow.rst
+++ b/src/user-guide/running-workflows/reflow.rst
@@ -122,7 +122,7 @@ Triggering with No Active Flows
    task in it. The task's flow number will be the same as if you
    had triggered it just before the workflow completed.
 
-Special Case: Triggering ``n=0`` (:term:`active tasks <active task`)
+Special Case: Triggering ``n=0`` (:term:`active tasks <active task>`)
    Active tasks already have flow membership assigned.
    Flow numbers are inherited, on entering the active wndow, from parent
    (upstream) tasks in the graph.

--- a/src/user-guide/running-workflows/tasks-jobs-ui.rst
+++ b/src/user-guide/running-workflows/tasks-jobs-ui.rst
@@ -104,31 +104,26 @@ The "n" Window
 
 .. versionchanged:: 8.0.0
 
-Cylc workflow :term:`graphs <graph>` can be very large, even infinite for
-:term:`cycling workflows <cycling workflow>` with no :term:`final cycle point`.
+Cylc workflow :term:`graphs <graph>` can be very large, or infinite in
+extent for :term:`cycling workflows <cycling workflow>` with no
+:term:`final cycle point`.
 
 Consequently the GUI often can't display "all of the tasks" at once. Instead
-it displays all :term:`active tasks <active task>` (e.g. running tasks)
-as well as any tasks which are a configurable number of tasks away from
-them in the task dependency :term:`graph`.
+it displays all tasks a configurable :term:`n-window` around the current
+:term:`active tasks <active task>`.
 
 .. image:: ../../img/n-window.png
    :align: center
 
 
 n=0:
-   The ``n=0`` window contains :term:`active tasks <active task>`. An active
-   task is a task which is near ready to run, in the process of running, or
-   which requires user intervention (see the :term:`glossary <active task>`
-   for a more detailed description).
+   The ``n=0`` window contains current :term:`active tasks`: those that are
+   near ready to run, running, or which require user intervention.
 n=1:
-   The ``n=1`` window contains all "active tasks" as well as any tasks one
-   "edge" out from them, i.e. their dependencies (the tasks that come immediately
-   before them in the graph) and their descendants (the tasks that come
-   immediately after them in the graph).
+   The ``n=1`` window contains the ``n=0`` tasks plus those out
+   to *one* graph edge around them in the graph.
 n=2:
-   The ``n=2`` window contains all "active tasks" as well as any tasks *two*
-   edges out from them, and so on.
+   The ``n=2`` window extends out to *two* graph edges from ``n=0``.
 
 This animation shows how the n-window advances as a workflow runs, tasks are
 colour coded according to their n-window value with the colours changing from

--- a/src/user-guide/running-workflows/tasks-jobs-ui.rst
+++ b/src/user-guide/running-workflows/tasks-jobs-ui.rst
@@ -109,7 +109,7 @@ extent for :term:`cycling workflows <cycling workflow>` with no
 :term:`final cycle point`.
 
 Consequently the GUI often can't display "all of the tasks" at once. Instead
-it displays all tasks a configurable :term:`n-window` around the current
+it displays all tasks in a configurable :term:`n-window` around the current
 :term:`active tasks <active task>`.
 
 .. image:: ../../img/n-window.png
@@ -118,7 +118,7 @@ it displays all tasks a configurable :term:`n-window` around the current
 
 n=0:
    The ``n=0`` window contains current :term:`active tasks <active task>`: those
-   that are near ready to run, running, or which require user intervention.
+   that are near ready to run, running, or which may require user intervention.
 n=1:
    The ``n=1`` window contains the ``n=0`` tasks plus those out
    to *one* graph edge around them in the graph.

--- a/src/user-guide/running-workflows/tasks-jobs-ui.rst
+++ b/src/user-guide/running-workflows/tasks-jobs-ui.rst
@@ -117,8 +117,8 @@ it displays all tasks a configurable :term:`n-window` around the current
 
 
 n=0:
-   The ``n=0`` window contains current :term:`active tasks`: those that are
-   near ready to run, running, or which require user intervention.
+   The ``n=0`` window contains current :term:`active tasks <active task>`: those
+   that are near ready to run, running, or which require user intervention.
 n=1:
    The ``n=1`` window contains the ``n=0`` tasks plus those out
    to *one* graph edge around them in the graph.

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -5,7 +5,7 @@ Workflow Completion
 
 A workflow can :term:`shut down <shutdown>` once all
 :term:`active tasks <active task>` complete without spawning further
-downstream activity - i.e., when :term:`n=0 window` empties out.
+downstream activity - i.e., when :term:`n=0 window <n-window>` empties out.
 
 .. _scheduler stall:
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -12,10 +12,13 @@ downstream activity - i.e., when :term:`n=0 window <n-window>` empties out.
 Scheduler Stall
 ===============
 
-If there are no tasks waiting on as yet unsatisfied external constraints
-such clock and xtriggers, and all activity has ceased but workflow has
-not :ref:`run to completion <workflow completion>`, then it
-has stalled and requires manual intervention to continue.
+A workflow has stalled if:
+
+* No tasks are waiting on unstatisfied external events, like clock triggers and xtriggers.
+* AND All activity has ceased.
+* AND The workflow has not run to completion.
+
+A workflow which has stalled requires manual intervention to continue.
 
 Stalls are caused by :term:`final status incomplete tasks <output completion>`
 and :term:`partially satisfied tasks <prerequisite>`.

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -3,43 +3,37 @@
 Workflow Completion
 ===================
 
-A workflow is complete, and the scheduler will automatically
-:term:`shut down <shutdown>`, if no tasks remain in the
-:term:`n=0 <n-window>`.
-
-That is, all active tasks have finished, and no tasks remain waiting on
-:term:`prerequisites <prerequisite>` or "external" constraints (such as
-:term:`xtriggers <xtrigger>` or task :term:`hold`).
-
-If no active tasks remain and all external constraints are satisfied,
-but the n=0 window contains tasks waiting with partially satisfied
-:term:`prerequisites <prerequisite>`, or tasks with :term:`final status` and
-:term:`incomplete outputs <output completion>`, then the workflow is
-not complete and the scheduler will :term:`stall` pending manual intervention.
-
+A workflow can :term:`shut down <shutdown>` once all
+:term:`active tasks <active task>` complete without spawning further
+downstream activity - i.e., when :term:`n=0 window` empties out.
 
 .. _scheduler stall:
 
 Scheduler Stall
 ===============
 
-A stalled workflow has not run to :term:`completion <workflow completion>`
-but cannot continue without manual intervention. 
+If there are no tasks waiting on as yet unsatisfied external constraints
+such clock and xtriggers, and all activity has ceased but workflow has
+not :ref:`run to completion <workflow completion>`, then it
+has stalled and requires manual intervention to continue.
+
+Stalls are caused by :term:`final status incomplete tasks <output completion>`
+and :term:`partially satisfied tasks <prerequisite>`.
+
+These most often result from task failures that the workflow does not
+handle automatically by retries or optional branching.
 
 A stalled scheduler stays alive for a configurable timeout period
-pending manual intervention. If it shuts down (on the stall timeout
-or otherwise) it will remain in the stalled state on restart.
+to allow you to intervene, e.g. by manually triggering an incomplete
+task after fixing the bug that caused it to fail.
 
-Stalls are often caused by unexpected task failures, either directly (tasks
-with :term:`final status` and :term:`incomplete outputs <output completion>`)
-or indirectly (tasks with partially satisfied :term:`prerequisites <prerequisite>`,
-downstream of an unexpected failure).
+If a stalled workflow does eventually shut down, on the stall timeout
+or by stop command, it will immediately stall again on restart.
 
 .. warning::
 
-   At present you have to consult the :term:`scheduler log` to see the reason
-   for a stall.
-
+   At present you have to look at the :term:`scheduler log` to see
+   which tasks caused a stall.
 
 .. seealso::
 

--- a/src/user-guide/running-workflows/workflow-completion.rst
+++ b/src/user-guide/running-workflows/workflow-completion.rst
@@ -31,12 +31,12 @@ to allow you to intervene, e.g. by manually triggering an incomplete
 task after fixing the bug that caused it to fail.
 
 If a stalled workflow does eventually shut down, on the stall timeout
-or by stop command, it will immediately stall again on restart.
+or by stop command, it will immediately stall again on restart to await
+manual intervention.
 
 .. warning::
 
-   At present you have to look at the :term:`scheduler log` to see
-   which tasks caused a stall.
+   Look in the :term:`scheduler log` to see which tasks caused a stall.
 
 .. seealso::
 

--- a/src/user-guide/task-implementation/skip-mode.rst
+++ b/src/user-guide/task-implementation/skip-mode.rst
@@ -14,8 +14,8 @@ Skip mode is designed as an aid to workflow control:
 * It allows skipping of tasks in a running workflow using either:
   * ``cylc broadcast -s 'run mode = skip'`` (for when it is ready to run).
   This will work with any future task or family.
-  * ``cylc set --out skip`` (to immediately skip). This only works with
-  globs for active tasks. Otherwise task names must be explicit.
+  * ``cylc set --out skip`` (to immediately skip). Note that globs only match
+  :term:`active tasks <active task>`. Otherwise task names must be explicit.
 
 .. note::
 

--- a/src/user-guide/troubleshooting.rst
+++ b/src/user-guide/troubleshooting.rst
@@ -295,7 +295,11 @@ Why is my task stuck in the waiting state - |task-waiting|?
 Tasks in the "waiting" state are waiting for something to happen before Cylc
 will submit them.
 
-To find out what is holding the task back from running:
+To find out what is holding the task back from running use ``cylc show``.
+
+Note, at present ``cylc show`` can only display tasks in the current
+:term:`n-window`. However, waiting tasks beyond ``n=0``, by definition,
+have no satisfied prerequisites.
 
 .. tab-set::
 

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -843,7 +843,7 @@ Late Events
   The scheduler can only check for lateness once a task becomes
   :term:`active <active task>`. In Cylc 8 this usually means the task
   is ready, or nearly ready, to run, which limits the usefulness of late
-  events as currently implemented.
+  events.
 
 If a real time (clock-triggered) workflow performs fairly consistently from one
 cycle to the next, you may want to be notified when certain tasks are running

--- a/src/user-guide/writing-workflows/runtime.rst
+++ b/src/user-guide/writing-workflows/runtime.rst
@@ -527,6 +527,9 @@ or submit-failed using these task configurations:
    Configure retries for jobs which failed during submission so never ran
    (submit-failed jobs - |job-submit-failed|).
 
+Tasks that fail but are configured to :term:`retry` return to the ``waiting``
+state, with a new clock trigger to handle the configured retry delay.
+
 Retry delays should be set to a list of
 :term:`ISO8601 durations <ISO8601 duration>` that specify how long to wait
 before retrying the task again, e.g:
@@ -621,8 +624,8 @@ Advanced Example
 Aborting a Retry Sequence
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To prevent a task from retrying, remove it from the scheduler's
-:term:`active window`, e.g:
+To prevent a task from retrying, remove it from the
+:term:`n=0 window <n-window>`.
 
 .. code-block:: console
 
@@ -837,10 +840,10 @@ Late Events
 
 .. warning::
 
-  The scheduler can only check for lateness once a task has appeared in its
-  active task window. In Cylc 8 this is usually when the task is actually
-  ready to run, which severely limits the usefulness of late events as
-  currently implemented.
+  The scheduler can only check for lateness once a task becomes
+  :term:`active <active task>`. In Cylc 8 this usually means the task
+  is ready, or nearly ready, to run, which limits the usefulness of late
+  events as currently implemented.
 
 If a real time (clock-triggered) workflow performs fairly consistently from one
 cycle to the next, you may want to be notified when certain tasks are running

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1534,7 +1534,7 @@ So, in the cycle ``2000-01-01T00:00Z``:
 * ``foo`` would expire at ``2000-01-01T00:00Z``.
 * ``bar`` would expire at ``2000-01-01T01:00Z``.
 
-Only waiting tasks can expire, :term:`active tasks <active>` will not be
+Only waiting tasks can expire, :term:`active tasks <active task>` will not be
 killed if they pass their configured ``clock-expire`` time.
 
 When a task expires, it produces the ``expired`` :term:`output`.
@@ -2219,16 +2219,22 @@ executing, e.g:
 Runahead Limiting
 -----------------
 
-Runahead limiting prevents workflow activity from getting too far ahead of the
-earliest :term:`active cycle`, by holding back tasks in cycles beyond a
-configurable limit.
+Runahead limiting restricts workflow activity to a configurable number of
+cycles beyond the earliest :term:`active cycle`.
 
-Tasks in cycles beyond the runahead limit are called "runahead limited" and are
-displayed in the GUI/Tui with small circle above them:
+.. TODO - update this after https://github.com/cylc/cylc-flow/issues/5580:
+
+Tasks in the :term:`n=0 window <n-window>` at the runahead limit are actively
+held back, and are displayed in the GUI/Tui with a small circle above them.
 
 .. image:: ../../img/task-job-icons/task-isRunahead.png
    :width: 60px
    :height: 60px
+
+.. note::
+
+   Tasks in the :term:`n=1 window <n-window>` are not displayed as runahead
+   limited; they form the future graph and are not yet being actively limited.
 
 As the workflow advances and active cycles complete, the runahead limit moves
 forward allowing tasks in later cycles to run.

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1623,7 +1623,7 @@ Tasks are expected to complete required outputs at runtime, but
 they don't have to complete optional outputs.
 
 This allows the scheduler to correctly diagnose
-:term:`workflow completion`. [2]_
+:ref:`workflow completion`. [2]_
 
 Tasks that achieve a :term:`final status` without completing their
 outputs [3]_ are retained in the :term:`n=0 window <n-window>` pending user
@@ -2219,15 +2219,12 @@ executing, e.g:
 Runahead Limiting
 -----------------
 
-Runahead limiting prevents a workflow from getting too far ahead of the oldest
-active cycle point by holding back tasks in cycles beyond a specified limit.
+Runahead limiting prevents workflow activity from getting too far ahead of the
+earliest :term:`active cycle`, by holding back tasks in cycles beyond a
+configurable limit.
 
-The runahead limit is defined as an interval measured from the oldest active cycle.
-A cycle is considered to be "active" if it contains any :term:`active` tasks
-(e.g. running tasks).
-
-Tasks in cycles which are beyond the limit are called :term:`runahead` tasks
-and are displayed in the GUI/Tui with small circle above them:
+Tasks in cycles beyond the runahead limit are called "runahead limited" and are
+displayed in the GUI/Tui with small circle above them:
 
 .. image:: ../../img/task-job-icons/task-isRunahead.png
    :width: 60px
@@ -2236,7 +2233,7 @@ and are displayed in the GUI/Tui with small circle above them:
 As the workflow advances and active cycles complete, the runahead limit moves
 forward allowing tasks in later cycles to run.
 
-There are two ways of defining the interval which defines the runahead limit,
+There are two ways of defining the interval which defines the runahead limit:
 as an integer number of cycles, or as a datetime interval.
 
 

--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -2233,7 +2233,7 @@ held back, and are displayed in the GUI/Tui with a small circle above them.
 
 .. note::
 
-   Tasks in the :term:`n=1 window <n-window>` are not displayed as runahead
+   Tasks in the :term:`n>=1 window <n-window>` are not displayed as runahead
    limited; they form the future graph and are not yet being actively limited.
 
 As the workflow advances and active cycles complete, the runahead limit moves

--- a/src/user-guide/writing-workflows/suicide-triggers.rst
+++ b/src/user-guide/writing-workflows/suicide-triggers.rst
@@ -16,8 +16,7 @@ Suicide Triggers
    a rare :ref:`edge case <remaining-use-cases>`.
 
 
-Suicide triggers remove waiting :term:`tasks <task>` from the
-:term:`scheduler's <scheduler>` active :term:`active window` at runtime.
+Suicide triggers remove waiting tasks from the :term:`n=0 window <n-window>`.
 
 They are activated just like normal :term:`task triggers <task trigger>` but
 they remove the downstream task (prefixed with ``!``) instead of triggering it


### PR DESCRIPTION
(This branch is a few months old; it supersedes #798 which tried to be lighter weight but was still confusing).

Our overloading of the term "active" is still confusing:
- *"active tasks"* typically means tasks with active jobs
   - (for historical reasons that don't really matter anymore)
- the *"active window"* (of the workflow) is the scheduler task pool 
   - (task pool is no longer a user-facing term)
   - the active window contains many tasks that are "not active"!
- the *`n=0` window* is identical to the "active window"
   - (the latter term predates the former, but we kept both for reasons that don't really matter anymore)
- we now use the terms "active" and "inactive" internally, in scheduler code, to distinguish pool and future tasks

**This PR resolves the problem by dropping the redundant term "active window" and redefining "active task" slightly:**
- an **"active task"** is a task under active management by the scheduler (i.e. in the task pool).
- active tasks comprise the **n=0 window** of the workflow

Rationale:
- with task/job separation we don't need a special term for a *task* with an active job
- the active window *should* contain just the active tasks, by any sensible definition of the terms
- but we have to use "n=0 window" for other reasons anyway, so we might as well drop the redundant term
  - (however, this change makes "active window" perfectly compatible with "active tasks" and "n=0 window", so no biggie, and not confusing anymore, if we still use the term accidentally or otherwise)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
