### PR TITLE
Remove an inaccurate sentence.

### DIFF
--- a/src/user-guide/writing-workflows/scheduling.rst
+++ b/src/user-guide/writing-workflows/scheduling.rst
@@ -1935,8 +1935,7 @@ The ``?`` symbol denotes an :term:`optional output` which allows the graph to
 branch.
 
 Note the last line of the graph ``c | r => d`` allows the graph to
-continue on to ``d`` regardless of the path taken. This is an :term:`artificial
-dependency`.
+continue on to ``d`` regardless of the path taken.
 
 This is a simple example of a "switch" pattern, the task ``b`` being the switch
 in this case, the ``succeeded`` / ``failed`` outputs deciding which pathway


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f531dbe1-cb80-4615-aa3e-5ba1c2972482)

Artificial dependency, as defined in the glossary:

> An artificial [dependency](https://cylc.github.io/cylc-doc/stable/html/glossary.html#term-dependency) in the graph does not reflect real dependence between the tasks involved. This can sometimes be useful but should be avoided if possible. Artificial dependencies muddy the real dependencies of the workflow and they may unnecessarily constrain the scheduler.

This dependency `c | r:fail => d` is not artificial because `d` presumably does depend on real outputs of the upstream tasks. The fact that either one of the branches can generate the outputs doesn't make the dependency artificial.

`git blame` fingers me for this, although the commit name suggests I was combining existing doc sections, so I'm not sure if there is an original author out there who might disagree with this change.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
