### PR TITLE
Add sphinx copybutton extension

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     hieroglyph>=2.1.0
     setuptools>=50
     sphinx>=7.1, !=7.4.4
+    sphinx-copybutton
     sphinx-design>=0.5.0
     sphinx_rtd_theme>=1.0.0
     sphinxcontrib-svg2pdfconverter

--- a/src/conf.py
+++ b/src/conf.py
@@ -57,6 +57,7 @@ def generate_task_icon_modifier_rst():
 sys.path.append(os.path.abspath('ext'))  # path to custom extensions.
 extensions = [
     # sphinx built-in extensions
+    'sphinx_copybutton',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.graphviz',

--- a/src/conf.py
+++ b/src/conf.py
@@ -333,3 +333,6 @@ wordsfile.write_text('\n'.join(words) + '\n')
 # Create sentence case versions of wordlist:
 sentence_case = [word.capitalize() for word in words]
 sentence_case_file.write_text('\n'.join(sentence_case) + '\n')
+
+# Turn off copybutton for diffs
+copybutton_selector = "div:not(.highlight-diff) > div.highlight > pre"


### PR DESCRIPTION
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

Add a copy button to code snippets.

<img width="756" height="240" alt="image" src="https://github.com/user-attachments/assets/609f8058-f99f-442c-82c3-6e994d949256" />

I've wanted to do this for ages, but last time I looked this extension didn't exist. 

Built at https://████████████████/doc/cylc/8.5.2.dev/html/tutorial/scheduling/graphing.html#example
