### PR TITLE
Additions to and reordering of tutorial bullet points

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,4 +18,3 @@ Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>                   
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak       <tomasz.trzeciak@metoffice.gov.uk>
 Thomas Coleman  <15375218+ColemanTom@users.noreply.github.com>
 Samuel Denton <samuel.denton@metoffice.gov.uk> samuel-denton <samuel.denton@metoffice.gov.uk>
- 

--- a/.mailmap
+++ b/.mailmap
@@ -17,3 +17,5 @@ Sadie Bartholomew <sadie.bartholomew@metoffice.gov.uk>  Sadie L. Bartholomew <30
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>                       <TomekTrzeciak@users.noreply.github.com>
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak       <tomasz.trzeciak@metoffice.gov.uk>
 Thomas Coleman  <15375218+ColemanTom@users.noreply.github.com>
+Samuel Denton <samuel.denton@metoffice.gov.uk> samuel-denton <samuel.denton@metoffice.gov.uk>
+ 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ requests_).
  - Elliot Fontaine
  - Mark Dawson
  - James Frost
+ - Samuel Denton
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -114,6 +114,7 @@ parentless
 passX
 passphrase
 passwordless
+pdf
 performant
 pings
 placeholder
@@ -136,6 +137,7 @@ prepended
 preprocessing
 preset
 proc
+profiler
 programmatically
 proleptic
 py

--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -23,17 +23,13 @@ The :cylc:conf:`flow.cylc` File Format
 
 .. ifnotslides::
 
-   * Sections are written inside square brackets i.e. ``[section-name]``.
-
-        * In this tutorial you will see; ``[scheduler]`` and ``[scheduling]``, 
-        a later tutorial will introduce ``[runtime]``.
-
-   * Sections can be nested, by adding an extra square bracket with each level,
-     so a sub-section would be written ``[[sub-section]]``, a sub-sub-section
-     ``[[[sub-sub-section]]]``, and so on.
-   * Settings are written as ``key = value`` pairs.
-   * Settings can be contained within sections.
-   * Cylc uses a special language to describe task recurrence and dependencies.
+   * :cylc:conf:`flow.cylc` files are divided into sections, written inside square
+     brackets, i.e. ``[section-name]``.
+   * In this tutorial you will see ``[scheduler]`` and ``[scheduling]``. 
+   * Sections are nested by adding extra brackets: ``[[sub-section]]``, 
+     ``[[[sub-sub-section]]]``, etc.
+   * Settings are written as ``key = value`` pairs within any section.
+   * Cylc uses a dedicated syntax to describe task recurrence and dependencies.
    * Comments start with a ``#`` character.
 
    .. note::

--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -23,13 +23,18 @@ The :cylc:conf:`flow.cylc` File Format
 
 .. ifnotslides::
 
-   * Comments start with a ``#`` character.
-   * Settings are written as ``key = value`` pairs.
-   * Settings can be contained within sections.
    * Sections are written inside square brackets i.e. ``[section-name]``.
+
+        * In this tutorial you will see; ``[scheduler]`` and ``[scheduling]``, 
+        a later tutorial will introduce ``[runtime]``.
+
    * Sections can be nested, by adding an extra square bracket with each level,
      so a sub-section would be written ``[[sub-section]]``, a sub-sub-section
      ``[[[sub-sub-section]]]``, and so on.
+   * Settings are written as ``key = value`` pairs.
+   * Settings can be contained within sections.
+   * Cylc uses a special language to describe task recurrence and dependencies.
+   * Comments start with a ``#`` character.
 
    .. note::
 

--- a/src/tutorial/scheduling/graphing.rst
+++ b/src/tutorial/scheduling/graphing.rst
@@ -29,7 +29,6 @@ The :cylc:conf:`flow.cylc` File Format
    * Sections are nested by adding extra brackets: ``[[sub-section]]``, 
      ``[[[sub-sub-section]]]``, etc.
    * Settings are written as ``key = value`` pairs within any section.
-   * Cylc uses a dedicated syntax to describe task recurrence and dependencies.
    * Comments start with a ``#`` character.
 
    .. note::


### PR DESCRIPTION
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

I have suggested a slight change in the order of bullet points as well as a few additions.
In my opinion, the bullets read better in this order, however, visually I prefer them ordered by line length as previous.

Original:
<img width="869" height="615" alt="image" src="https://github.com/user-attachments/assets/5d522ace-613e-47ca-b09e-8623d0f0bd53" />

My order with additions:
<img width="869" height="615" alt="image" src="https://github.com/user-attachments/assets/5c6ae278-ce76-427c-98c4-9a85b6d19943" />

Length order with additions:
<img width="940" height="644" alt="image" src="https://github.com/user-attachments/assets/5286d4b2-77d9-4022-a0ea-a3bcb3c8b93f" />


(This is intentionally a small PR with minimal changes to test my Git procedure)