### PR TITLE
Force external links to open in a new tab

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -17,3 +17,4 @@ Sadie Bartholomew <sadie.bartholomew@metoffice.gov.uk>  Sadie L. Bartholomew <30
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>                       <TomekTrzeciak@users.noreply.github.com>
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak       <tomasz.trzeciak@metoffice.gov.uk>
 Thomas Coleman  <15375218+ColemanTom@users.noreply.github.com>
+Samuel Denton <samuel.denton@metoffice.gov.uk> samuel-denton <samuel.denton@metoffice.gov.uk>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ requests_).
  - Elliot Fontaine
  - Mark Dawson
  - James Frost
+ - Samuel Denton
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -20,10 +20,12 @@
   height: 7em !important;
 }
 
-/* Add an icon to external links */
-a.external::after {
-  font-size: small;
+/* Add an icon to external links, excluding those with the "image-reference" class */
+a.external:not(.image-reference)::after {
+  font-size: 0.7em;
   font-weight: bolder;
-  content: "↗";
   margin-left: 0.3em;
+  vertical-align: super;
+  opacity: 0.5;
+  content: "↗";
 }

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -22,7 +22,8 @@
 
 /* Add an icon to external links */
 a.external::after {
-  content: "🔗 ↗ ⧉";
+  font-size: small;
+  font-weight: bolder;
+  content: "↗";
   margin-left: 0.3em;
-  color: black;
 }

--- a/src/_static/js/extern_links_new_tab.js
+++ b/src/_static/js/extern_links_new_tab.js
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('a.external').forEach(link => {
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener noreferrer');
-        link.setAttribute('title', 'This link will open in a new tab and take you to an external site.');
+        link.setAttribute('title', 'Opens in a new tab.');
         link.setAttribute('aria-label', 'External link: opens in a new tab');
     });
 });

--- a/src/_static/js/extern_links_new_tab.js
+++ b/src/_static/js/extern_links_new_tab.js
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * ------------------------------------------------------------------------- */
 
-/* Fix zero height auto size of svg */
-.logo {
-  height: 7em !important;
-}
-
-/* Add an icon to external links */
-a.external::after {
-  content: "🔗 ↗ ⧉";
-  margin-left: 0.3em;
-  color: black;
-}
+/*
+    Adds target=_blank to external links so they open in a new tab:
+    - noopener: prevents the new page accessing window.opener (tabnabbing protection)
+    - noreferrer: removes referrer info and adds extra safety
+*/
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll('a.external').forEach(link => {
+        link.setAttribute('target', '_blank');
+        link.setAttribute('rel', 'noopener noreferrer');
+    });
+});

--- a/src/_static/js/extern_links_new_tab.js
+++ b/src/_static/js/extern_links_new_tab.js
@@ -24,5 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('a.external').forEach(link => {
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener noreferrer');
+        link.setAttribute('title', 'This link will open in a new tab and take you to an external site.');
+        link.setAttribute('aria-label', 'External link: opens in a new tab');
     });
 });

--- a/src/_static/js/extern_links_new_tab.js
+++ b/src/_static/js/extern_links_new_tab.js
@@ -19,6 +19,7 @@
     Adds target=_blank to external links so they open in a new tab:
     - noopener: prevents the new page accessing window.opener (tabnabbing protection)
     - noreferrer: removes referrer info and adds extra safety
+    - title and aria-label: provide context for screen readers and tooltips
 */
 document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('a.external').forEach(link => {

--- a/src/_templates/layout.html
+++ b/src/_templates/layout.html
@@ -1,1 +1,14 @@
+<script type="text/javascript">
+    /*
+        Adds target=_blank to external links so they open in a new tab:
+        - noopener: prevents the new page accessing window.opener (tabnabbing protection)
+        - noreferrer: removes referrer info and adds extra safety
+    */
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll('a.external').forEach(link => {
+            link.setAttribute('target', '_blank');
+            link.setAttribute('rel', 'noopener noreferrer');
+        });
+    });
+</script>
 {% extends "!layout.html" %}

--- a/src/_templates/layout.html
+++ b/src/_templates/layout.html
@@ -1,14 +1,1 @@
-<script type="text/javascript">
-    /*
-        Adds target=_blank to external links so they open in a new tab:
-        - noopener: prevents the new page accessing window.opener (tabnabbing protection)
-        - noreferrer: removes referrer info and adds extra safety
-    */
-    document.addEventListener("DOMContentLoaded", function () {
-        document.querySelectorAll('a.external').forEach(link => {
-            link.setAttribute('target', '_blank');
-            link.setAttribute('rel', 'noopener noreferrer');
-        });
-    });
-</script>
 {% extends "!layout.html" %}

--- a/src/conf.py
+++ b/src/conf.py
@@ -239,18 +239,29 @@ html_context = {
     'sidebar_version_name': None,  # override name in version picker
 }
 
-html_static_path = ['_static']
-
-# These paths are either relative to html_static_path
-# or fully qualified paths (eg. https://...)
-html_css_files = ['css/custom.css']
-
 # Disable timestamp otherwise inserted at bottom of every page.
 html_last_updated_fmt = ''
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'cylcdoc'
 
+# -- Static file locations -----------------------------------------------
+html_static_path = ['_static']
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+# NOTE: these are added to the end of the default/theme static files, so
+# will override them if there are any conflicts.
+
+# Custom CSS
+html_css_files = [
+    'css/custom.css',
+]
+
+# Custom JS
+html_js_files = [
+    'js/extern_links_new_tab.js',
+]
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
Closes #908 if agreed.

Added some JavaScript to the theme layout which Adds target=_blank to external links so they open in a new tab.
I have seen some discourse online as to whether developers should try to effect the users choice when clicking links (they can already chose to open links in a new tab themselves), however in our case, external links are almost always definitions or further reading type of stuff so it feels a bit jarring for them to take you away from the docs.

Also added an icon and hover text to external links making them obvious.

Built example:
https://wwwspice/~samuel.denton/cylc-doc/8.6.x_Ext_links_new_tab/html/tutorial/scheduling/graphing.html
<img width="635" height="34" alt="image" src="https://github.com/user-attachments/assets/febd0c20-f97d-4c44-a3fb-460e94c52d97" />

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
