### PR TITLE
Remove upper pin on eralchemy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     cylc-sphinx-extensions>=1.4.1
-    eralchemy==1.2.*
+    eralchemy>=1.2
     hieroglyph>=2.1.0
     packaging
     sphinx>=7.1, !=7.4.4

--- a/src/conf.py
+++ b/src/conf.py
@@ -201,6 +201,8 @@ linkcheck_ignore = [
     'https?://matrix.to/.*#.*',
     # Blocked by bot protection:
     'https?://www.iso.org',
+    # Frequently rate-limited:
+    'https?://upload.wikimedia.org/wikipedia/commons/.*',
 ]
 
 # -- Options for Slides output ----------------------------------------------


### PR DESCRIPTION
Was getting an error building the docs in a new Python 3.14 environment

> libcgraph.so.7: cannot open shared object file: No such file or directory

Removing upper pin on erlachemy fixed it for me

<details><summary>Logs</summary>
 
```
Versions
========

* Platform:         linux; (Linux-5.14.0-611.54.1.el9_7.x86_64-x86_64-with-glibc2.34)
* Python version:   3.14.4 (CPython)
* Sphinx version:   9.1.0
* Docutils version: 0.22.4
* Jinja2 version:   3.1.6
* Pygments version: 2.20.0

Last Messages
=============

None.

Loaded Extensions
=================

None.

Traceback
=========

    Traceback (most recent call last):
      File "~/.conda/envs/c8/lib/python3.14/site-packages/sphinx/registry.py", line 550, in load_extension
        mod = import_module(extname)
      File "~/.conda/envs/c8/lib/python3.14/importlib/__init__.py", line 88, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
               ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "<frozen importlib._bootstrap>", line 1406, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
      File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 759, in exec_module
      File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
      File "~/github/cylc-doc/src/ext/database_diagram.py", line 27, in <module>
        from eralchemy.main import all_to_intermediary
      File "~/.conda/envs/c8/lib/python3.14/site-packages/eralchemy/__init__.py", line 3, in <module>
        from eralchemy.main import render_er
      File "~/.conda/envs/c8/lib/python3.14/site-packages/eralchemy/main.py", line 6, in <module>
        from pygraphviz.agraph import AGraph
      File "~/.conda/envs/c8/lib/python3.14/site-packages/pygraphviz/__init__.py", line 24, in <module>
        from .agraph import AGraph, Node, Edge, Attribute, ItemAttribute, DotError
      File "~/.conda/envs/c8/lib/python3.14/site-packages/pygraphviz/agraph.py", line 17, in <module>
        from . import graphviz as gv
      File "~/.conda/envs/c8/lib/python3.14/site-packages/pygraphviz/graphviz.py", line 10, in <module>
        from . import _graphviz
    ImportError: libcgraph.so.7: cannot open shared object file: No such file or directory
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "~/.conda/envs/c8/lib/python3.14/site-packages/sphinx/cmd/build.py", line 414, in build_main
        app = Sphinx(
            srcdir=args.sourcedir,
        ...<14 lines>...
            exception_on_warning=args.exception_on_warning,
        )
      File "~/.conda/envs/c8/lib/python3.14/site-packages/sphinx/application.py", line 299, in __init__
        self.setup_extension(extension)
        ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
      File "~/.conda/envs/c8/lib/python3.14/site-packages/sphinx/application.py", line 505, in setup_extension
        self.registry.load_extension(self, extname)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "~/.conda/envs/c8/lib/python3.14/site-packages/sphinx/registry.py", line 553, in load_extension
        raise ExtensionError(
            __('Could not import extension %s') % extname, err
        ) from err
    sphinx.errors.ExtensionError: Could not import extension database_diagram (exception: libcgraph.so.7: cannot open shared object file: No such file or directory)

```

</details>

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
