### PR TITLE
Added an 'Edit on GitHub' button to every page.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -218,7 +218,8 @@ slide_theme_options = {'custom_css': 'css/slides-custom.css'}
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
     'logo_only': True,
-    'navigation_depth': 4
+    'navigation_depth': 4,
+    'vcs_pageview_mode': 'edit',
 }
 html_logo = "img/cylc-logo-white.svg"
 html_favicon = "img/cylc-favicon.ico"  # sphinx specifies .ico format
@@ -239,6 +240,11 @@ html_sidebars = {
 # sphinx-build opt `-A name=value` (add to SPHINXOPTS if using make).
 html_context = {
     'sidebar_version_name': None,  # override name in version picker
+    'display_github': True,
+    'github_user': 'cylc',
+    'github_repo': 'cylc-doc',
+    'github_version': 'master',
+    'conf_py_path': '/src/',
 }
 
 # Disable timestamp otherwise inserted at bottom of every page.


### PR DESCRIPTION
Added here:
<img width="583" height="98" alt="image" src="https://github.com/user-attachments/assets/f4abbb10-1e8a-46fe-af12-22d66f8033c0" />

and links to either:
<img width="934" height="293" alt="image" src="https://github.com/user-attachments/assets/ff77c039-d305-41e7-b85e-d2c0c0764d23" />

Or to:
<img width="939" height="286" alt="image" src="https://github.com/user-attachments/assets/6f090c82-4e47-46d5-8ac4-132ed3272075" />

Working example:
https://wwwspice/~samuel.denton/cylc-doc/edit_this_page_btn/html/index.html

I think I am leaning towards linking to the page, not the editor, but I could be convinced either way.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
