### PR TITLE
GH Actions: do not run linkcheck in nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  FORCE_COLOR: 'true'
+  PIP_PROGRESS_BAR: 'off'
+
 jobs:
   set-meta-releases:
     # read the meta-release versions from the branches.json file
@@ -144,12 +148,10 @@ jobs:
           builddir="nightly_${{ matrix.meta_release }}"
           make -C docs \
             html \
-            linkcheck \
             SPHINXOPTS="-Wn --keep-going -A sidebar_version_name=${version}" \
             STABLE=false \
             LATEST=false \
-            BUILDDIR="doc/$builddir" \
-            FORCE_COLOR=true
+            BUILDDIR="doc/$builddir"
           git -C gh-pages add "$builddir" 'versions.json'
 
       - name: debug - pip list


### PR DESCRIPTION
I have just spotted this is causing constant failures of the nightly build for no good reason. Linkcheck is a check that runs on PRs and should not prevent deploying of the nightly docs.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
