### PR TITLE
Fix a typo in shared access doc.

### DIFF
--- a/src/reference/config/sharing-access-to-workflows.rst
+++ b/src/reference/config/sharing-access-to-workflows.rst
@@ -160,7 +160,7 @@ Authorization is configured by these two configurations:
        "user1": ["READ"],
 
        # allow "user2" to monitor and trigger tasks in my workflows
-       "user2": ["READ", "Trigger"],
+       "user2": ["READ", "trigger"],
    }
 
 


### PR DESCRIPTION
Example shared auth config does not work as currently written.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
