### PR TITLE
add cgroup to the dictionary

### DIFF
--- a/src/dictionaries/words
+++ b/src/dictionaries/words
@@ -15,6 +15,8 @@ booleans
 broadcasted
 bugfixes
 cfg
+cgroup
+cgroups
 changelog
 changelogs
 conf


### PR DESCRIPTION
Fix docs build errors by adding `cgroup` and `cgroups` to the internal dictionary.

Along with https://github.com/cylc/cylc-flow/pull/7389 this should fix build errors.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
